### PR TITLE
Use jinja2 and pyramid_jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
 
 requires = [
     'pyramid',
+    'pyramid_jinja2',
     'pyramid_chameleon',
     'pyramid_debugtoolbar',
-    'pyramid_mako',
     'pyramid_tm',
     'SQLAlchemy',
     'transaction',


### PR DESCRIPTION
As discussed we'll use jinja2 as the template engine/language. This commit removes the pyramid_mako dependency and adds the pyramid_jinja2 dependency. The pyramid_chameleon dependency will be removed in the future. It's not removed for now as the default page relies on it.