### PR TITLE
Add admin unit search web service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ test:
 dist: .build/venv
 	.build/venv/bin/python setup.py sdist
 
+.PHONY: dbtunnel
+dbtunnel:
+	@echo "Opening tunnel…"
+	ssh -N -L 9999:localhost:5432 wb-thinkhazard-dev-1.sig.cloud.camptocamp.net
+
 thinkhazard/static/build/build.css: $(LESS_FILES) .build/node_modules.timestamp
 	mkdir -p $(dir $@)
 	./node_modules/.bin/lessc thinkhazard/static/less/thinkhazard.less $@

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ help:
 	@echo
 	@echo "- install                 Install thinkhazard"
 	@echo "- build                   Build CSS and JS"
-	@echo "- initdb                  (Re-)initialize the database"
+	@echo "- initdb-dev              Initialize db using development.ini"
+	@echo "- initdb-prod             Initialize db using production.ini"
 	@echo "- serve                   Run the dev server"
 	@echo "- check                   Check the code with flake8, jshint and bootlint"
 	@echo "- modwsgi                 Create files for Apache mod_wsgi"
@@ -35,9 +36,13 @@ build: buildcss
 .PHONY: buildcss
 buildcss: thinkhazard/static/build/build.css thinkhazard/static/build/build.min.css
 
-.PHONY: initdb
-initdb:
+.PHONY: initdb-dev
+initdb-dev:
 	.build/venv/bin/initialize_thinkhazard_db development.ini
+
+.PHONY: initdb-prod
+initdb-prod:
+	.build/venv/bin/initialize_thinkhazard_db production.ini
 
 .PHONY: serve
 serve: build

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Create a Python virtual environment and install the project into it::
 
 Set up the project's database::
 
-    $ make initdb
+    $ make initdb-dev
 
 Run the development server::
 

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,18 @@ ThinkHazard
     :target: https://travis-ci.org/GFDRR/thinkhazard
     :alt: Travis CI Status
 
+System-level dependencies
+=========================
+
+The following packages must be installed on the system:
+
+* `libpq-dev`
+* `node`/`npm`
+* `gcc`
+* `python-devel`
+* `python-virtualenv`
+* `apache2`
+
 Getting Started
 ===============
 

--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,6 @@ Create a Python virtual environment and install the project into it::
 
     $ make install
 
-Set up the project's database::
-
-    $ make initdb-dev
-
 Run the development server::
 
     $ make serve

--- a/development.ini
+++ b/development.ini
@@ -16,7 +16,7 @@ pyramid.includes =
     pyramid_mako
     pyramid_tm
 
-sqlalchemy.url = sqlite:///%(here)s/thinkhazard.sqlite
+sqlalchemy.url = postgresql://www-data:www-data@localhost:9999/thinkhazard
 
 jinja2.filters =
     route_url = pyramid_jinja2.filters:route_url_filter

--- a/production.ini
+++ b/production.ini
@@ -15,7 +15,7 @@ pyramid.includes =
     pyramid_mako
     pyramid_tm
 
-sqlalchemy.url = sqlite:///%(here)s/thinkhazard.sqlite
+sqlalchemy.url = postgresql://www-data:www-data@localhost:5432/thinkhazard
 
 jinja2.filters =
     route_url = pyramid_jinja2.filters:route_url_filter

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
     CHANGES = f.read()
 
 requires = [
+    'psycopg2',
     'pyramid',
     'pyramid_jinja2',
     'pyramid_debugtoolbar',

--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -10,14 +10,21 @@ from .models import (
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
+
     config = Configurator(settings=settings)
+
     config.include('pyramid_jinja2')
+
     config.add_static_view('static', 'static', cache_max_age=3600)
     config.add_static_view('lib', settings.get('node_modules'),
                            cache_max_age=86000)
+
     config.add_route('index', '/')
+    config.add_route('adminunit', '/adminunit')
+
     config.scan()
     return config.make_wsgi_app()

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -1,11 +1,10 @@
 from sqlalchemy import (
     Column,
-    Index,
     Integer,
-    Text,
+    Unicode,
     )
 
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.declarative import declarative_base, AbstractConcreteBase
 
 from sqlalchemy.orm import (
     scoped_session,
@@ -18,10 +17,38 @@ DBSession = scoped_session(sessionmaker(extension=ZopeTransactionExtension()))
 Base = declarative_base()
 
 
-class MyModel(Base):
-    __tablename__ = 'models'
-    id = Column(Integer, primary_key=True)
-    name = Column(Text)
-    value = Column(Integer)
+class Admin(AbstractConcreteBase, Base):
+    __table_args__ = {'schema': 'adminunits'}
 
-Index('my_index', MyModel.name, unique=True, mysql_length=255)
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode)
+
+
+class Admin0(Admin):
+    __tablename__ = 'admin0'
+    order = 0
+
+    def __json__(self, request):
+        return {'admin0': self.name}
+
+
+class Admin1(Admin):
+    __tablename__ = 'admin1'
+    order = 1
+
+    admin0_name = Column(Unicode)
+
+    def __json__(self, request):
+        return {'admin0': self.admin0_name, 'admin1': self.name}
+
+
+class Admin2(Admin):
+    __tablename__ = 'admin2'
+    order = 2
+
+    admin0_name = Column(Unicode)
+    admin1_name = Column(Unicode)
+
+    def __json__(self, request):
+        return {'admin0': self.admin0_name, 'admin1': self.admin1_name,
+                'admin2': self.name}

--- a/thinkhazard/scripts/initializedb.py
+++ b/thinkhazard/scripts/initializedb.py
@@ -13,7 +13,6 @@ from pyramid.scripts.common import parse_vars
 
 from ..models import (
     DBSession,
-    MyModel,
     Base,
     )
 
@@ -36,5 +35,4 @@ def main(argv=sys.argv):
     DBSession.configure(bind=engine)
     Base.metadata.create_all(engine)
     with transaction.manager:
-        model = MyModel(name='one', value=1)
-        DBSession.add(model)
+        pass

--- a/thinkhazard/static/js/index.js
+++ b/thinkhazard/static/js/index.js
@@ -12,28 +12,13 @@
       return tokens;
     },
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    local: [{
-      admin0: 'Morocco'
-    }, {
-      admin0: 'Morocco',
-      admin1: 'Chaouia-Ouardigha'
-    }, {
-      admin0: 'Morocco',
-      admin1: 'Chaouia-Ouardigha',
-      admin2: 'Ben Slimane'
-    }, {
-      admin0: 'Morocco',
-      admin1: 'Chaouia-Ouardigha',
-      admin2: 'Khouribga'
-    }, {
-      admin0: 'Morocco',
-      admin1: 'Chaouia-Ouardigha',
-      admin2: 'Settat'
-    }, {
-      admin0: 'Morocco',
-      admin1: 'Chaouia-Ouardigha',
-      admin2: 'Berrechid'
-    }]
+    limit: 10,
+    remote: {
+      url: app.adminunitUrl + '?q=%QUERY',
+      filter: function(parsedResponse) {
+        return parsedResponse.data;
+      }
+    }
   });
 
   engine.initialize();

--- a/thinkhazard/static/js/index.js
+++ b/thinkhazard/static/js/index.js
@@ -39,4 +39,11 @@
     source: engine.ttAdapter()
   });
 
+  $('#search-field').on('typeahead:selected',
+      function(e, d) {
+        var admin = d.admin2 || d.admin1 || d.admin0;
+        window.alert('You selected ' + admin);
+      }
+  );
+
 })();

--- a/thinkhazard/templates/index.jinja2
+++ b/thinkhazard/templates/index.jinja2
@@ -33,6 +33,10 @@
     <script src="{{('%s/bootstrap/dist/js/bootstrap.min.js' % node_modules)|static_url}}"></script>
     <script src="{{('%s/typeahead.js/dist/typeahead.bundle.min.js' % node_modules)|static_url}}"></script>
 {% endif %}
+    <script>
+      var app = {};
+      app.adminunitUrl = '{{'adminunit'|route_url}}';
+    </script>
     <script src="{{'thinkhazard:static/js/index.js'|static_url}}"></script>
   </body>
 </html>

--- a/thinkhazard/views.py
+++ b/thinkhazard/views.py
@@ -1,4 +1,31 @@
+import itertools
+
 from pyramid.view import view_config
+from pyramid.httpexceptions import HTTPBadRequest
+
+from .models import DBSession, Admin0, Admin1, Admin2
+
+
+def roundrobin(*iterables, **kwargs):
+    """
+    This function is a derivate of the roundrobin function provided in the
+    itertools documentation page.
+
+    https://docs.python.org/3/library/itertools.html#itertools-recipes
+    """
+    limit = kwargs.get('limit', float('inf'))
+    pending = len(iterables)
+    nexts = itertools.cycle(iter(it).next for it in iterables)
+    while pending:
+        try:
+            for next in nexts:
+                yield next()
+                limit -= 1
+                if limit == 0:
+                    return
+        except StopIteration:
+            pending -= 1
+            nexts = itertools.cycle(itertools.islice(nexts, pending))
 
 
 @view_config(route_name='index', renderer='templates/index.jinja2')
@@ -7,3 +34,24 @@ def index(request):
     settings = request.registry.settings
     return {'debug': debug,
             'node_modules': settings.get('node_modules')}
+
+
+@view_config(route_name='adminunit', renderer='json')
+def adminunit(request):
+
+    if 'q' not in request.params:
+        raise HTTPBadRequest(detail='parameter "q" is missing')
+
+    ilike = '%s%%' % request.params['q']
+
+    admin0s = DBSession.query(Admin0).filter(
+        Admin0.name.ilike(ilike)).limit(10)
+    admin1s = DBSession.query(Admin1).filter(
+        Admin1.name.ilike(ilike)).limit(10)
+    admin2s = DBSession.query(Admin2).filter(
+        Admin2.name.ilike(ilike)).limit(10)
+
+    data = sorted(roundrobin(admin0s, admin1s, admin2s, limit=10),
+                  key=lambda o: o.order)
+
+    return {'data': data}


### PR DESCRIPTION
This PR adds a JSON web service for searching admin units, and make the search field rely on that search service.

The URL of the service is `/adminunit` and the `q` parameter is used for searching admin units. For example: `/adminunit?q=mor`.