### PR TITLE
Add Pyramid's cache buster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,8 @@ help:
 	@echo
 
 .PHONY: install
-install: setup-develop .build/node_modules.timestamp
+install: .build/requirements.timestamp .build/node_modules.timestamp
 	
-.PHONY: setup-develop
-setup-develop: .build/venv
-	.build/venv/bin/python setup.py develop
-
 .PHONY: build
 build: buildcss
 
@@ -60,7 +56,7 @@ routes:
 check: flake8 jshint bootlint
 
 .PHONY: flake8
-flake8: .build/requirements.timestamp .build/flake8.timestamp
+flake8: .build/dev-requirements.timestamp .build/flake8.timestamp
 
 .PHONY: jshint
 jshint: .build/node_modules.timestamp .build/jshint.timestamp
@@ -85,7 +81,7 @@ dbtunnel:
 	ssh -N -L 9999:localhost:5432 wb-thinkhazard-dev-1.sig.cloud.camptocamp.net
 
 .PHONY: watchless
-watchless: .build/requirements.timestamp
+watchless: .build/dev-requirements.timestamp
 	@echo "Watching less files…"
 	.build/venv/bin/nosier -p thinkhazard/static/less "make thinkhazard/static/build/index.css thinkhazard/static/build/report.css"
 
@@ -110,9 +106,14 @@ thinkhazard/static/build/%.css: $(LESS_FILES) .build/node_modules.timestamp
 	npm install
 	touch $@
 
+.build/dev-requirements.timestamp: .build/venv dev-requirements.txt
+	mkdir -p $(dir $@)
+	.build/venv/bin/pip install -r dev-requirements.txt > /dev/null 2>&1
+	touch $@
+
 .build/requirements.timestamp: .build/venv requirements.txt
 	mkdir -p $(dir $@)
-	.build/venv/bin/pip install -r requirements.txt > /dev/null 2>&1
+	.build/venv/bin/pip install -r requirements.txt
 	touch $@
 
 .build/flake8.timestamp: $(PY_FILES)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+#
+# This file defines the requirements.txt for development.
+#
+flake8==2.2.2
+pep8-naming==0.2.2
+nosier==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-#
-# This file defines the requirements.txt for development.
-#
-flake8==2.2.2
-pep8-naming==0.2.2
-nosier==1.1
+https://github.com/Pylons/pyramid/archive/1e02bbfc0df09259bf207112acf019c8dba44a90.zip#egg=pyramid
+-e .

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(here, 'CHANGES.rst')) as f:
 
 requires = [
     'psycopg2',
-    'pyramid',
+    'pyramid == 1.6.dev0',
     'pyramid_jinja2',
     'pyramid_debugtoolbar',
     'pyramid_tm',

--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -19,9 +19,10 @@ def main(global_config, **settings):
 
     config.include('pyramid_jinja2')
 
-    config.add_static_view('static', 'static', cache_max_age=3600)
+    config.add_static_view('static', 'static', cache_max_age=3600,
+                           cachebust=True)
     config.add_static_view('lib', settings.get('node_modules'),
-                           cache_max_age=86000)
+                           cache_max_age=86000, cachebust=True)
 
     config.add_route('index', '/')
     config.add_route('report', '/report')


### PR DESCRIPTION
With this PR we use Pyramid's cache buster for the application's static resources. This is to avoid problems because of the Varnish cache we use on AWS.

This requires using the development version of Pyramid (1.6.dev0), which we download from GitHub.