### PR TITLE
Using a custom template for typeahead, makes search results more readable

### DIFF
--- a/thinkhazard/static/js/search.js
+++ b/thinkhazard/static/js/search.js
@@ -23,20 +23,32 @@
 
   engine.initialize();
 
+  function getSortedTokens(s) {
+    var tokens = [s.admin0];
+    if (s.admin1) {
+      tokens.unshift(s.admin1);
+    }
+    if (s.admin2) {
+      tokens.unshift(s.admin2);
+    }
+    return tokens;
+  }
+
   $('#search-field').typeahead({
     highlight: true
   }, {
     displayKey: function(s) {
-      var tokens = [s.admin0];
-      if (s.admin1) {
-        tokens.push(s.admin1);
-      }
-      if (s.admin2) {
-        tokens.push(s.admin2);
-      }
-      return tokens.join(', ');
+      return getSortedTokens(s).join(', ');
     },
-    source: engine.ttAdapter()
+    source: engine.ttAdapter(),
+    templates: {
+      suggestion: function(data) {
+        var tokens = getSortedTokens(data);
+        tokens[0] += '<small><em>';
+        tokens[tokens.length - 1] += '</em></small>';
+        return tokens.join(', ');
+      }
+    }
   });
 
   $('#search-field').on('typeahead:selected',


### PR DESCRIPTION
Changed order of administrative levels and make the higher level more obvious in the search results so that it's more intuitive for the user.
See screenshots.

Before:
![screenshot from 2015-04-24 15 59 33](https://cloud.githubusercontent.com/assets/319774/7320172/0f9a0062-ea9b-11e4-8ae4-ca4a907ecadf.png)

After:
![screenshot from 2015-04-24 16 00 25](https://cloud.githubusercontent.com/assets/319774/7320176/16488cb2-ea9b-11e4-9eaf-2a69e94e66a1.png)
