### PR TITLE
Show subdivisions in map when no hazard type is selected

### DIFF
--- a/data/thinkhazard.xml
+++ b/data/thinkhazard.xml
@@ -33,7 +33,7 @@
 
 <Style name="admindivcommon">
   <Rule>
-    <TextSymbolizer fontset-name="fontset-0" fill="#000000" size="9"
+    <TextSymbolizer fontset-name="fontset-0" fill="#000000" size="12"
         halo-fill="rgba(255, 255, 255, 0.5)" halo-radius="1"
         line-spacing="1" ><![CDATA[[name]]]>
     </TextSymbolizer>

--- a/data/thinkhazard.xml
+++ b/data/thinkhazard.xml
@@ -55,8 +55,8 @@
     <PolygonSymbolizer fill="#e0b025" fill-opacity="0.3" />
   </Rule>
   <Rule>
-    <ElseFilter />
-    <PolygonSymbolizer fill="#87988c" fill-opacity="0.3" />
+    <Filter>[category] = 'NPR'</Filter>
+    <PolygonSymbolizer fill="#e0b025" fill-opacity="0.3" />
   </Rule>
 </Style>
 


### PR DESCRIPTION
With this PR the division boundaries are drawn on the map even when there's no hazard type selected. This PR also increases the map font size.

Fixes https://github.com/GFDRR/thinkhazard/issues/43 https://github.com/GFDRR/thinkhazard/issues/38.