### PR TITLE
Change admin division geometry to 3857

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -196,7 +196,7 @@ class AdministrativeDivision(Base):
     parent_code = Column(Integer, ForeignKey(
         'administrativedivision.code', use_alter=True,
         name='administrativedivision_parent_code_fkey'))
-    geometry_wgs84 = Column(Geometry('MULTIPOLYGON', 4326))
+    geom = Column(Geometry('MULTIPOLYGON', 3857))
 
     leveltype = relationship(AdminLevelType)
     parent = relationship('AdministrativeDivision', uselist=False,

--- a/thinkhazard/views/map.py
+++ b/thinkhazard/views/map.py
@@ -35,7 +35,7 @@ def _create_map_object(division_code, hazard_type, mapfile, rasterfile,
     map_.layers.append(layer)
 
     division_geometry, division_leveltype = DBSession.query(
-        AdministrativeDivision.geometry_wgs84, AdminLevelType.mnemonic) \
+        AdministrativeDivision.geom, AdminLevelType.mnemonic) \
         .join(AdministrativeDivision.leveltype) \
         .filter(AdministrativeDivision.code == division_code).one()
 
@@ -66,7 +66,7 @@ def _create_map_object(division_code, hazard_type, mapfile, rasterfile,
         feature['name'] = subdivision.name
         feature['code'] = subdivision.code
         feature['category'] = category
-        shape = geoalchemy2.shape.to_shape(subdivision.geometry_wgs84)
+        shape = geoalchemy2.shape.to_shape(subdivision.geom)
         feature.add_geometries_from_wkb(shape.wkb)
         division_datasource.add_feature(feature)
 


### PR DESCRIPTION
This commit changes the SRID of the admin division geometry column from 4326 to 3857. It also renames the column from geometry_wgs84 to geom.