### PR TITLE
Remove OpenLayers 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "jquery": "~2.1.3",
     "jshint": "~2.5.1",
     "less": "~1.7.5",
-    "openlayers": "~3.3.0",
     "typeahead.js": "~0.10.5",
     "typeahead.js-bootstrap3.less": "hyspace/typeahead.js-bootstrap3.less#a512760"
   }

--- a/thinkhazard/static/less/report.less
+++ b/thinkhazard/static/less/report.less
@@ -1,4 +1,2 @@
-@import (inline) "../../../node_modules/openlayers/css/ol.css";
-
 @import "common.less";
 @import "report-layout.less";

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -94,11 +94,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block scripts %}
-{% if debug %}
-    <script src="{{('%s/openlayers/dist/ol-debug.js' % node_modules)|static_url}}"></script>
-{% else %}
-    <script src="{{('%s/openlayers/dist/ol.js' % node_modules)|static_url}}"></script>
-{% endif %}
-{% endblock %}


### PR DESCRIPTION
This PR removes OpenLayers 3 entirely. For now. We may revisit this choice in the future.