### PR TITLE
Add Additional Information to the report pages

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -165,17 +165,6 @@ hazardcategory_administrativedivision_table = Table(
            ForeignKey('hazardcategory.id'), nullable=False, index=True))
 
 
-hazardcategory_additionalinformation_table = Table(
-    'rel_hazardcategory_additionalinformation', Base.metadata,
-    Column('id', Integer, primary_key=True),
-    Column('additionalinformation_id', Integer,
-           ForeignKey('additionalinformation.id'), nullable=False, index=True),
-    Column('hazardcategory_id', Integer,
-           ForeignKey('hazardcategory.id'),
-           nullable=False, index=True),
-    Column('additionalinformationorder', Integer, nullable=False))
-
-
 class HazardCategoryRecommendationAssociation(Base):
     __tablename__ = 'rel_hazardcategory_recommendation'
 
@@ -187,6 +176,20 @@ class HazardCategoryRecommendationAssociation(Base):
     recommendationorder = Column(Integer, nullable=False)
 
     recommendation = relationship('Recommendation', lazy='joined')
+
+
+class HazardCategoryAdditionalInformationAssociation(Base):
+    __tablename__ = 'rel_hazardcategory_additionalinformation'
+    id = Column(Integer, primary_key=True)
+    hazardcategory_id = Column(Integer, ForeignKey('hazardcategory.id'),
+                               nullable=False, index=True)
+    additionalinformation_id = Column(Integer,
+                                      ForeignKey('additionalinformation.id'),
+                                      nullable=False, index=True)
+    additionalinformationorder = Column(Integer, nullable=False)
+
+    additionalinformation = relationship('AdditionalInformation',
+                                         lazy='joined')
 
 
 class AdministrativeDivision(Base):
@@ -290,6 +293,11 @@ class HazardCategory(Base):
     recommendation_associations = relationship(
         'HazardCategoryRecommendationAssociation',
         order_by='HazardCategoryRecommendationAssociation.recommendationorder',
+        lazy='joined')
+    additionalinformation_associations = relationship(
+        'HazardCategoryAdditionalInformationAssociation',
+        order_by='HazardCategoryAdditionalInformationAssociation.'
+                 'additionalinformationorder',
         lazy='joined')
 
 

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -79,6 +79,12 @@
                 <p>{{ recommendation_association.recommendation.description }}</p>
                 {% endfor %}
                 {% endif %}
+                {% if hazard.additionalinfo_associations %}
+                <h2>Additional Information</h2>
+                {% for additionalinfo_association in hazard.additionalinfo_associations %}
+                <p><a href="{{ additionalinfo_association.additionalinformation.accessurl }}">{{ additionalinfo_association.additionalinformation.title }}</a></p>
+                {% endfor %}
+                {% endif %}
               </div>
             </div>
             {% endfor %}

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -7,6 +7,7 @@ from ..models import (
     CategoryType,
     HazardCategory,
     HazardCategoryRecommendationAssociation,
+    HazardCategoryAdditionalInformationAssociation,
     HazardType)
 
 
@@ -38,7 +39,8 @@ def report(request):
     hazard_data = {hazardtype.mnemonic: {'hazardtype': hazardtype,
                                          'categorytype': _categorytype_nodata,
                                          'description': None,
-                                         'recommendation_associations': None}
+                                         'recommendation_associations': None,
+                                         'additionalinfo_associations': None}
                    for hazardtype in hazardtype_query}
 
     # Query 3: get the hazard categories corresponding to the administrative
@@ -47,6 +49,9 @@ def report(request):
         .join(HazardCategory.administrativedivisions) \
         .join(HazardCategory.recommendation_associations) \
         .join(HazardCategoryRecommendationAssociation.recommendation) \
+        .join(HazardCategory.additionalinformation_associations) \
+        .join(HazardCategoryAdditionalInformationAssociation
+              .additionalinformation) \
         .join(HazardType) \
         .join(CategoryType) \
         .filter(AdministrativeDivision.code == division_code)
@@ -58,6 +63,8 @@ def report(request):
         hazard_data[key]['description'] = hazardcategory.description
         hazard_data[key]['recommendation_associations'] = \
             hazardcategory.recommendation_associations
+        hazard_data[key]['additionalinfo_associations'] = \
+            hazardcategory.additionalinformation_associations
 
     # Order the hazard data by category type (hazard types with the highest
     # risk are first in the UI).


### PR DESCRIPTION
This adds the additional information to report pages. Please review.

![additionalinformation](https://cloud.githubusercontent.com/assets/76594/7563504/3001b782-f7de-11e4-8231-cdb2d6c49638.png)


Fixes https://github.com/GFDRR/thinkhazard/issues/66.