### PR TITLE
Go back to overview page when division link is clicked

### DIFF
--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -12,8 +12,8 @@
   var offsets = new Array(2);
 
   // Change the tab to active in the tablist when a item is selected
-  // in the "default" tabpanel
-  $('#default a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
+  // in the "overview" tabpanel
+  $('#overview a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
     var target = this.href.split('#');
     $('ul.hazards a').filter('[href="#' + target[1] + '"]').tab('show');
   });
@@ -24,6 +24,15 @@
     var target = this.href.split('#');
     hazardType = target[1];
     addMap(hazardType);
+  });
+
+  // Show the "overview" list when the division-name link is clicked
+  $('#division-name').on('click', function() {
+    if (hazardType) {
+      $('ul.hazards a').filter('[href="#overview"]').tab('show');
+      hazardType = undefined;
+      addMap(hazardType);
+    }
   });
 
   // Add a new map to the page when the window changes size

--- a/thinkhazard/static/less/report-layout.less
+++ b/thinkhazard/static/less/report-layout.less
@@ -102,7 +102,12 @@ html, body {
   h2 {
     margin-top: 0;
     font-family: 'variablebold';
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
   }
+
   h3 {
     text-transform: uppercase;
     font-size: 12px;
@@ -113,15 +118,16 @@ html, body {
     font-size: 12px;
     a {
       color: inherit;
-      &:hover {
-        text-decoration: none;
-      }
+      text-decoration: none;
     }
   }
 
   ul.hazards {
     background-color: #f2f2f2;
     height: 90px;
+    > li:first-child {
+      display: none;
+    }
     li {
       vertical-align: top;
       background-color: #f2f2f2;

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -35,9 +35,12 @@
           <div class="logo-gfdrr"></div>
           <a id="pdf-link" href><img src="{{('thinkhazard:static/images/download.png'|static_url)}}">Download PDF</a>
           <h3>Report on Hazards</h3>
-          <h2>{{ division.name }}</h2>
+          <h2><a id="division-name" href="#" title="Go back to overview page">{{ division.name }}</a>&nbsp;</h2>
           <h4><a href="{{ 'report'|route_url(_query={'divisioncode': parent_division.code}) }}" title="Report on hazards in {{ parent_division.name }}">{{ parent_division.name}}</a>&nbsp;</h4>
           <ul id="hazard-types-list" class="horizontal list-unstyled hazards" role="tablist">
+            <li>
+              <a href="#overview"></a>
+            </li>
             {% for hazard in hazards %}
             <li class="{{ hazard.categorytype.mnemonic }}">
               <a href="#{{ hazard.hazardtype.mnemonic }}" aria-controls="{{ hazard.hazardtype.title }}" role="tab" data-toggle="tab">
@@ -50,7 +53,7 @@
         </div>
         <div id="report-body">
           <div class="container-fluid scrollable tab-content">
-            <div id="default" class="row tab-pane active" role="tabpanel">
+            <div id="overview" class="row tab-pane active" role="tabpanel">
               <div class="col-md-12 overview">
               {% for hazard in hazards %}
                 <a href="#{{ hazard.hazardtype.mnemonic }}" aria-controls="{{ hazard.hazardtype.title }}" role="tab" data-toggle="tab">


### PR DESCRIPTION
This changes the division name text to a link in the report page. And when that link is clicked we go back to the "overview" content.

Please review.

Fixes https://github.com/GFDRR/thinkhazard/issues/60.