### PR TITLE
Add hash in url for selected hazard type

### DIFF
--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -21,10 +21,18 @@
   // Reload the map when a hazard type is selected
   var hazardType;
   $('#hazard-types-list a[data-toggle="tab"]').on('shown.bs.tab', function(e) {
-    var target = this.href.split('#');
-    hazardType = target[1];
+    var hash = this.hash;
+    hazardType = hash.substr(1);
     addMap(hazardType);
+    window.location.hash = hash;
   });
+
+  // detect any change on hash (history back for example)
+  $(window).bind('hashchange', showTab);
+  // Load the hazard if already defined URL hash
+  if (window.location.hash) {
+    showTab();
+  }
 
   // Show the "overview" list when the division-name link is clicked
   $('#division-name').on('click', function() {
@@ -83,12 +91,18 @@
     var yRelative = offsets[1] / h;
     var data = getDataForPosition(xRelative, yRelative);
     if (data) {
-      window.location.href = app.reportpageUrl + '?divisioncode=' + data.code;
+      showDivision(data.code);
     }
   });
 
   // Add the map to the page
   addMap(hazardType);
+
+  $('.drillup').on('click', function(e) {
+    var code = $(this).attr('data-code');
+    showDivision(code);
+    return false;
+  });
 
   /**
    * Return the UTFGrid data for a position (x, y). `null` is returned
@@ -167,4 +181,22 @@
     });
   }
 
+  /**
+   * Load page for given division code.
+   */
+  function showDivision(code) {
+    var url = app.reportpageUrl + '?divisioncode=' + code;
+    if (hazardType) {
+      url  += '#' + hazardType;
+    }
+    window.location.href = url;
+  }
+
+  /**
+   * Take the hash from URL to activate the tab corresponding to the hazard
+   * type.
+   */
+  function showTab() {
+    $('#hazard-types-list a[href=' + window.location.hash + ']').tab('show');
+  }
 })();

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -36,7 +36,7 @@
           <a id="pdf-link" href><img src="{{('thinkhazard:static/images/download.png'|static_url)}}">Download PDF</a>
           <h3>Report on Hazards</h3>
           <h2><a id="division-name" href="#" title="Go back to overview page">{{ division.name }}</a>&nbsp;</h2>
-          <h4><a href="{{ 'report'|route_url(_query={'divisioncode': parent_division.code}) }}" title="Report on hazards in {{ parent_division.name }}">{{ parent_division.name}}</a>&nbsp;</h4>
+          <h4><a class="drillup" href="#" data-code="{{ parent_division.code }}" title="Report on hazards in {{ parent_division.name }}">{{ parent_division.name}}</a>&nbsp;</h4>
           <ul id="hazard-types-list" class="horizontal list-unstyled hazards" role="tablist">
             <li>
               <a href="#overview"></a>
@@ -100,7 +100,7 @@
     <div id="map-wrapper" class="">
       <div id="map">
         {% if parent_division %}
-        <a id="map-drillup" class="btn btn-default" href="{{ 'report'|route_url(_query={'divisioncode': parent_division.code}) }}">
+        <a id="map-drillup" class="btn btn-default drillup" href="#" data-code="{{ parent_division.code }}">
           <img src="{{('thinkhazard:static/images/zoom-out.png'|static_url)}}">
           Zoom out to {{ parent_division.name }}
         </a>


### PR DESCRIPTION
Allows to keep hazard when drilling up/down to other division

Fixes https://github.com/GFDRR/thinkhazard/issues/79.