### PR TITLE
Add returnperiod_id column to metadata table

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -261,7 +261,7 @@ class Metadata(Base):
     hazardsetid = Column(Integer)
     glidenumber = Column(Integer)
     intensityunit = Column(Unicode)
-    returnperiod = Column(Integer)
+    returnperiod_id = Column(Integer, ForeignKey(ReturnPeriod.id))
     mdauthorindividualorganisationnames = Column(Unicode)
 
     datetype = relationship(MetadataDateType)
@@ -272,6 +272,7 @@ class Metadata(Base):
     language = relationship(MetadataLanguage)
     topiccategory = relationship(MetadataTopicCategory)
     countryregion = relationship(AdministrativeDivision)
+    returnperiod = relationship(ReturnPeriod)
     hazardtype = relationship(HazardType)
 
 


### PR DESCRIPTION
This is to reflect a correction by the BRGM team on the schema.