### PR TITLE
Make it possible to create user instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 LESS_FILES = $(shell find thinkhazard/static/less -type f -name '*.less' 2> /dev/null)
 JS_FILES = $(shell find thinkhazard/static/js -type f -name '*.js' 2> /dev/null)
 PY_FILES = $(shell find thinkhazard -type f -name '*.py' 2> /dev/null)
+INSTANCEID ?= main
 
 .PHONY: all
 all: help
@@ -135,6 +136,7 @@ thinkhazard/static/build/%.css: $(LESS_FILES) .build/node_modules.timestamp
 
 .build/apache.conf: apache.conf .build/venv
 	sed -e 's#{{PYTHONPATH}}#$(shell .build/venv/bin/python -c "import distutils; print(distutils.sysconfig.get_python_lib())")#' \
+		-e 's#{{INSTANCEID}}#$(INSTANCEID)#' \
 		-e 's#{{WSGISCRIPT}}#$(abspath .build/venv/thinkhazard.wsgi)#' $< > $@
 
 .PHONY: clean

--- a/apache.conf
+++ b/apache.conf
@@ -1,11 +1,11 @@
 WSGIPassAuthorization On
 
-WSGIDaemonProcess thinkhazard display-name=%{GROUP} user=www-data group=staff \
+WSGIDaemonProcess thinkhazard:{{INSTANCEID}} display-name=%{GROUP} user=www-data group=staff \
     python-path={{PYTHONPATH}}
 
-WSGIScriptAlias /thinkhazard/wsgi {{WSGISCRIPT}}
+WSGIScriptAlias /{{INSTANCEID}}/wsgi {{WSGISCRIPT}}
 
-<Location /thinkhazard/wsgi>
-    WSGIProcessGroup thinkhazard
+<Location /{{INSTANCEID}}/wsgi>
+    WSGIProcessGroup thinkhazard:{{INSTANCEID}}
     WSGIApplicationGroup %{GLOBAL}
 </Location>


### PR DESCRIPTION
With this PR one can use `make modwsgi INSTANCEID=myuserid` to generate an Apache mod_wsgi config declaring a WSGI application at `/myuserid/wsgi`. By default `INSTANCEID` is `main`, meaning that the demo instance will be available at `/main/wsgi` (instead of `/thinkhazard/wsgi` as today).