### PR TITLE
Add simplejson as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requires = [
     'pyramid_jinja2',
     'pyramid_debugtoolbar',
     'pyramid_tm',
+    'simplejson',
     'SQLAlchemy',
     'shapely',
     'transaction',


### PR DESCRIPTION
simplejson is necessary when using Papyrus' GeoJSON renderer.