### PR TITLE
Make make clean remove timestamp files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ thinkhazard/static/build/%.css: $(LESS_FILES) .build/node_modules.timestamp
 clean:
 	rm -f .build/thinkhazard-*.wsgi
 	rm -f .build/apache-*.conf
+	rm -f .build/flake8.timestamp
+	rm -f .build/jshint.timestamp
+	rm -f .build/booltlint.timestamp
+	rm -f .build/fonts.timestamp
 	rm -rf thinkhazard/static/build
 
 .PHONY: cleanall


### PR DESCRIPTION
This PR makes `make clean` remove `.timestamp` files. It removes the `.timestamp` files that can be quickly rebuilt. For example, it won't remove `mode_modules.timestamp`, because re-installing all the node dependencies takes a long time. `make cleanall` is the target to use to remove all the build artifacts.