### PR TITLE
Hazard type (alignment + overview)

### DIFF
--- a/thinkhazard/static/less/common.less
+++ b/thinkhazard/static/less/common.less
@@ -65,6 +65,17 @@ ul.horizontal li {
   font-family: 'variablelight', sans-serif;
 }
 
+.page-header {
+  position: relative;
+  small {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    font-style: italic;
+    padding-bottom: ((@line-height-computed / 2) - 1);
+  }
+}
+
 
 /*************
  * typeahead *

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -77,10 +77,9 @@ Think Hazard - {{ division.name}}
         {% if current_hazard %}
           <h2 class="page-header detail">
             {{ current_hazard.hazardtype.title }}
-            <em>
-              <small class="pull-right">Hazard level: <span class="level">{{ current_hazard.categorytype.title }}</span>
-              </small>
-            </em>
+            <small>
+              Hazard level: <span class="level">{{ current_hazard.categorytype.title }}</span>
+            </small>
           </h2>
           {% if current_hazard.description %}
           {{ current_hazard.description }}
@@ -100,10 +99,9 @@ Think Hazard - {{ division.name}}
           <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}">
             <h1 class="page-header level-{{ hazard.categorytype.mnemonic }}">
               {{ hazard.hazardtype.title }}
-              <em>
-                <small class="pull-right">Hazard level: <span class="level">{{ hazard.categorytype.title }}</span>
-                </small>
-              </em>
+              <small>
+                Hazard level: <span class="level">{{ hazard.categorytype.title }}</span>
+              </small>
             </h1>
           </a>
           {% endfor %}

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -96,8 +96,8 @@ Think Hazard - {{ division.name}}
           {% endif %}
         {% else %}
           {% for hazard in hazards %}
-          <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}">
-            <h1 class="page-header level-{{ hazard.categorytype.mnemonic }}">
+          <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}" class="level-{{ hazard.categorytype.mnemonic }}">
+            <h1 class="page-header">
               {{ hazard.hazardtype.title }}
               <small>
                 Hazard level: <span class="level">{{ hazard.categorytype.title }}</span>


### PR DESCRIPTION
With this pull request I have fix bad alignment of hazard type and level.
I also have fixed styling when displayed in overview.
Please review.