### PR TITLE
Add a hazard level arrow in report

### DIFF
--- a/thinkhazard/static/less/common.less
+++ b/thinkhazard/static/less/common.less
@@ -1,6 +1,7 @@
 @import "bootstrap.less";
 @import "web-fonts.less";
 @import "icons.less";
+@import "variables.less";
 
 @fa-font-path: "fonts";
 
@@ -17,7 +18,6 @@
 @input-border: #ccc;
 @input-border-focus: #58595b;
 @input-border-radius: 5px;
-@jumbotron-bg: #f2f2f2;
 
 @btn-default-border: #d9d9d9;
 
@@ -97,11 +97,11 @@ ul.horizontal li {
     margin-top: 50px;
     padding-top: 20px;
     &.no-data {
-      color: #a8a8a8;
+      color: @text-inactive;
       a,
       a:hover,
       .hazard-icon {
-        color: #a8a8a8;
+        color: @text-inactive;
       }
       .icon {
         background-color: #f5f5f5;

--- a/thinkhazard/static/less/common.less
+++ b/thinkhazard/static/less/common.less
@@ -68,7 +68,7 @@ ul.horizontal li {
   color: #333;
   small {
     position: absolute;
-    right: 0;
+    right: 40px;
     bottom: 0;
     font-style: italic;
     font-family: @font-family-base;

--- a/thinkhazard/static/less/report.less
+++ b/thinkhazard/static/less/report.less
@@ -76,6 +76,39 @@ body {
   }
 }
 
+.hazard-level {
+  background: @jumbotron-bg;
+  outline: .2em solid white;
+  position: absolute;
+  right: 40px;
+  text-align: center;
+  text-transform: uppercase;
+  transform: rotate(-90deg);
+  transform-origin: right top;
+  width: ~"calc(24.7em + 7px)";
+  z-index: 2;
+  &:before,
+  &:after {
+    border-left: 10px solid @jumbotron-bg;
+    border-bottom: 13px solid white;
+    border-top: 13px solid white;
+    content: "";
+    height: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    transform: scale(0.999);
+  }
+  &:before {
+    border-left-color: white;
+    border-bottom: 12px solid @jumbotron-bg;
+    border-top-color: @jumbotron-bg;
+    right: auto;
+    left: -1px;
+  }
+}
+
 .logo,
 .hazard-types-list a,
 .overview {

--- a/thinkhazard/static/less/report.less
+++ b/thinkhazard/static/less/report.less
@@ -1,5 +1,6 @@
 @import "../../../node_modules/bootstrap/less/variables.less";
 @import "../../../node_modules/bootstrap/less/mixins.less";
+@import "variables.less";
 
 @level-HIG-color: #d91f2d;
 @level-MED-color: #df7120;
@@ -78,6 +79,7 @@ body {
 
 .hazard-level {
   background: @jumbotron-bg;
+  color: @text-inactive;
   outline: .2em solid white;
   position: absolute;
   right: 40px;

--- a/thinkhazard/static/less/variables.less
+++ b/thinkhazard/static/less/variables.less
@@ -1,0 +1,2 @@
+@jumbotron-bg: #f2f2f2;
+@text-inactive: #a8a8a8;

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -119,6 +119,7 @@ Think Hazard - {{ division.name}}
           </ul>
           {% endif %}
         {% else %}
+          <aside class="hazard-level">Hazard level</aside>
           {% for hazard in hazards_sorted %}
           <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}" class="level-{{ hazard.hazardlevel.mnemonic }} overview">
             <h2 class="page-header">


### PR DESCRIPTION
Fix #319, tested in FF & Chrome.

![screenshot from 2015-12-09 15 46 44](https://cloud.githubusercontent.com/assets/21686/11688304/19ea5008-9e8c-11e5-99be-0bc740e27738.png)
