### PR TITLE
The decisiontree-selected hazardset source is displayed under the map

### DIFF
--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -122,7 +122,7 @@ Think Hazard - {{ division.name}}
           <aside class="hazard-level">Hazard level</aside>
           {% for hazard in hazards_sorted %}
           <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}" class="level-{{ hazard.hazardlevel.mnemonic }} overview">
-            <h2 class="page-header" title="{{hazard.association.source}}">
+            <h2 class="page-header">
               {{ hazard.hazardtype.title }}
               <small>
                 <span class="level">{{ hazard.hazardlevel.title }}</span>

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -122,7 +122,7 @@ Think Hazard - {{ division.name}}
           <aside class="hazard-level">Hazard level</aside>
           {% for hazard in hazards_sorted %}
           <a href="{{ 'report'|route_url(divisioncode=division.code, hazardtype=hazard.hazardtype.mnemonic) }}" aria-controls="{{ hazard.hazardtype.title }}" class="level-{{ hazard.hazardlevel.mnemonic }} overview">
-            <h2 class="page-header">
+            <h2 class="page-header" title="{{hazard.association.source}}">
               {{ hazard.hazardtype.title }}
               <small>
                 <span class="level">{{ hazard.hazardlevel.title }}</span>

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -180,7 +180,7 @@ Think Hazard - {{ division.name}}
 
           <div class="data-source text-center">
             <h5>DATA SOURCE</h5>
-            <div>** Put the sources here</div>
+            <div>HazardSet {{source}}</div>
           </div>
           {% endif %}
         </div>

--- a/thinkhazard/tests/__init__.py
+++ b/thinkhazard/tests/__init__.py
@@ -17,6 +17,8 @@ from thinkhazard_common.models import (
     HazardCategoryFurtherResourceAssociation,
     )
 
+from thinkhazard_common.utils import associate_admindiv_hazardcategory
+
 from shapely.geometry import (
     MultiPolygon,
     Polygon,
@@ -99,8 +101,8 @@ def populate_db():
     category_eq_hig.hazardlevel = DBSession.query(HazardLevel) \
         .filter(HazardLevel.mnemonic == u'HIG').one()
 
-    div_level_3_1.hazardcategories.append(category_eq_hig)
-    div_level_3_2.hazardcategories.append(category_eq_hig)
+    associate_admindiv_hazardcategory(div_level_3_1, category_eq_hig, u'test')
+    associate_admindiv_hazardcategory(div_level_3_2, category_eq_hig, u'test')
 
     climate_rec = ClimateChangeRecommendation()
     climate_rec.text = u'Climate change recommendation'
@@ -135,9 +137,9 @@ def populate_db():
     category_fl_med.hazardlevel = DBSession.query(HazardLevel) \
         .filter(HazardLevel.mnemonic == u'MED').one()
 
-    div_level_3_1.hazardcategories.append(category_fl_med)
+    associate_admindiv_hazardcategory(div_level_3_1, category_fl_med, u'test')
     DBSession.add(div_level_3_1)
-    div_level_3_2.hazardcategories.append(category_fl_med)
+    associate_admindiv_hazardcategory(div_level_3_2, category_fl_med, u'test')
     DBSession.add(div_level_3_2)
 
     further_resource = FurtherResource(**{

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -15,6 +15,7 @@ from thinkhazard_common.models import (
     AdministrativeDivision,
     HazardLevel,
     HazardCategory,
+    HazardCategoryAdministrativeDivisionAssociation,
     HazardType,
     ClimateChangeRecommendation,
     TechnicalRecommendation,
@@ -48,24 +49,29 @@ def report(request):
 
     # Get the hazard categories corresponding to the administrative
     # division whose code is division_code.
-    hazardcategories_query = DBSession.query(HazardCategory) \
-        .join(HazardCategory.administrativedivisions) \
+    associations_query = DBSession.query(
+        HazardCategoryAdministrativeDivisionAssociation) \
+        .join(AdministrativeDivision) \
+        .join(HazardCategory) \
         .join(HazardType) \
         .join(HazardLevel) \
         .filter(AdministrativeDivision.code == division_code)
 
-    # Create a dict with the categories. Keys are the hazard type mnemonic.
-    hazardcategories = {d.hazardtype.mnemonic: d
-                        for d in hazardcategories_query}
+    # Create a dict with the associations. Keys are the hazard type mnemonic.
+    associations = {d.hazardcategory.hazardtype.mnemonic: d
+                    for d in associations_query}
 
     hazard_types = []
     for hazardtype in hazardtype_query:
-        cat = _hazardlevel_nodata
-        if hazardtype.mnemonic in hazardcategories:
-            cat = hazardcategories[hazardtype.mnemonic].hazardlevel
+        hazardlevel = _hazardlevel_nodata
+        association = {'source': ''}
+        if hazardtype.mnemonic in associations:
+            association = associations[hazardtype.mnemonic]
+            hazardlevel = association.hazardcategory.hazardlevel
         hazard_types.append({
             'hazardtype': hazardtype,
-            'hazardlevel': cat
+            'hazardlevel': hazardlevel,
+            'association': association,
         })
 
     hazard_category = None

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -15,6 +15,7 @@ from thinkhazard_common.models import (
     AdministrativeDivision,
     HazardLevel,
     HazardCategory,
+    HazardCategoryAdministrativeDivisionAssociation,
     HazardType,
     ClimateChangeRecommendation,
     TechnicalRecommendation,

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -74,15 +74,17 @@ def report(request):
             'association': association,
         })
 
-    hazard_category = None
+    association = None
     technical_recommendations = None
     further_resources = None
     climate_change_recommendation = None
 
     if hazard is not None:
         try:
-            hazard_category = DBSession.query(HazardCategory) \
-                .join(HazardCategory.administrativedivisions) \
+            association = DBSession.query(
+                HazardCategoryAdministrativeDivisionAssociation) \
+                .join(AdministrativeDivision) \
+                .join(HazardCategory) \
                 .join(HazardLevel) \
                 .join(HazardType) \
                 .filter(HazardType.mnemonic == hazard) \
@@ -107,14 +109,14 @@ def report(request):
         technical_recommendations = DBSession.query(TechnicalRecommendation) \
             .join(TechnicalRecommendation.hazardcategory_associations) \
             .join(HazardCategory) \
-            .filter(HazardCategory.id == hazard_category.id) \
+            .filter(HazardCategory.id == association.hazardcategory.id) \
             .all()
 
         further_resources = DBSession.query(FurtherResource) \
             .join(FurtherResource.hazardcategory_associations) \
             .join(HazardCategory) \
             .outerjoin(AdministrativeDivision) \
-            .filter(HazardCategory.id == hazard_category.id) \
+            .filter(HazardCategory.id == association.hazardcategory.id) \
             .filter(or_(AdministrativeDivision.code == division_code,
                         AdministrativeDivision.code == null())) \
             .all()
@@ -165,7 +167,10 @@ def report(request):
     return {'hazards': hazard_types,
             'hazards_sorted': sorted(hazard_types,
                                      key=lambda a: a['hazardlevel'].order),
-            'hazard_category': hazard_category,
+            'hazard_category': association.hazardcategory
+            if association else '',
+            'source': association.source
+            if association else '',
             'climate_change_recommendation': climate_change_recommendation,
             'recommendations': technical_recommendations,
             'resources': further_resources,

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -15,7 +15,6 @@ from thinkhazard_common.models import (
     AdministrativeDivision,
     HazardLevel,
     HazardCategory,
-    HazardCategoryAdministrativeDivisionAssociation,
     HazardType,
     ClimateChangeRecommendation,
     TechnicalRecommendation,
@@ -49,29 +48,24 @@ def report(request):
 
     # Get the hazard categories corresponding to the administrative
     # division whose code is division_code.
-    associations_query = DBSession.query(
-        HazardCategoryAdministrativeDivisionAssociation) \
-        .join(AdministrativeDivision) \
-        .join(HazardCategory) \
+    hazardcategories_query = DBSession.query(HazardCategory) \
+        .join(HazardCategory.administrativedivisions) \
         .join(HazardType) \
         .join(HazardLevel) \
         .filter(AdministrativeDivision.code == division_code)
 
-    # Create a dict with the associations. Keys are the hazard type mnemonic.
-    associations = {d.hazardcategory.hazardtype.mnemonic: d
-                    for d in associations_query}
+    # Create a dict with the categories. Keys are the hazard type mnemonic.
+    hazardcategories = {d.hazardtype.mnemonic: d
+                        for d in hazardcategories_query}
 
     hazard_types = []
     for hazardtype in hazardtype_query:
-        hazardlevel = _hazardlevel_nodata
-        association = {'source': ''}
-        if hazardtype.mnemonic in associations:
-            association = associations[hazardtype.mnemonic]
-            hazardlevel = association.hazardcategory.hazardlevel
+        cat = _hazardlevel_nodata
+        if hazardtype.mnemonic in hazardcategories:
+            cat = hazardcategories[hazardtype.mnemonic].hazardlevel
         hazard_types.append({
             'hazardtype': hazardtype,
-            'hazardlevel': hazardlevel,
-            'association': association,
+            'hazardlevel': cat
         })
 
     association = None


### PR DESCRIPTION
This is a proposal for https://github.com/GFDRR/thinkhazard/issues/40

Here's a screenshot taken during tests:
![capture du 2015-12-14 14 55 33](https://cloud.githubusercontent.com/assets/265319/11782841/e08b27ba-a273-11e5-91eb-134b727463f9.png)
(in which the hazardset is named "test")

Also, tests had to be updated as a result of https://github.com/GFDRR/thinkhazard_common/pull/9