### PR TITLE
Workaround for typeahead issue not showing all results

### DIFF
--- a/thinkhazard/static/js/search.js
+++ b/thinkhazard/static/js/search.js
@@ -12,7 +12,6 @@
       return tokens;
     },
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    limit: 10,
     remote: {
       url: app.administrativedivisionUrl + '?q=%QUERY',
       wildcard: '%QUERY',
@@ -34,6 +33,7 @@
       return getSortedTokens(s).join(', ');
     },
     source: engine,
+    limit: Infinity,
     templates: {
       suggestion: function(data) {
         var tokens = getSortedTokens(data);


### PR DESCRIPTION
Fixes #358.

See https://github.com/twitter/typeahead.js/issues/1232 and https://github.com/twitter/typeahead.js/issues/1218