### PR TITLE
Update faq.jinja2: add/edit FAQs

### DIFF
--- a/thinkhazard/templates/faq.jinja2
+++ b/thinkhazard/templates/faq.jinja2
@@ -29,10 +29,18 @@
       <div class="col-md-12">
         <dl>
           <dt>
+          What are the aims of this tool?
+          </dt>
+          <dd>
+          <em>ThinkHazard!</em> is a simple tool that enables people to discover the level of hazard, for multiple hazards, in any location around the world. It aims to provide recommendations for actions that users can take to manage that hazard, and provide additional information relevant to the hazard and location. The tool draws on multiple data sources to provide the level of hazard, and is set-up to become increasingly comprehensive over time as users contribute new data and information
+          </dd>
+        </dl>
+        <dl>
+          <dt>
           What is the long term vision for the tool?
           </dt>
           <dd>
-          The long-term vision for <em>Think Hazard!</em> is that it becomes a place for users to explore and understand natural hazard levels around the world, and obtain guidance on how to consider natural hazards in their projects. <em>Think Hazard!</em> will continue to be updated, and we encourage users of <em>Think Hazard!</em> to provide feedback, hazard datasets that could improve it (especially at national, provincial and district levels), and additional resources (websites and publications) that can contribute to a growing repository of knowledge on this <em>Think Hazard!</em> website. Our intention to continuously update the hazard data to reflect the latest knowledge in each hazard.
+          The long-term vision for <em>ThinkHazard!</em> is that it becomes a place for users to explore and understand natural hazard levels around the world, and obtain guidance on how to consider natural hazards in their projects. <em>ThinkHazard!</em> will continue to be updated, and we encourage users of <em>ThinkHazard!</em> to provide feedback, hazard datasets that could improve it (especially at national, provincial and district levels), and additional resources (websites and publications) that can contribute to a growing repository of knowledge on this <em>ThinkHazard!</em> website. Our intention to continuously update the hazard data to reflect the latest knowledge in each hazard.
           </dd>
         </dl>
         <dl>
@@ -40,7 +48,7 @@
           Where can I get a more specific version for my type of projects?
           </dt>
           <dd>
-          This initial version of <em>Think Hazard!</em> is designed to be generic and not to provide specific recommendations for different sectors. Instead, we encourage partners who work in sectoral areas to work with us to produce sector (or project) specific versions of this tool, which would provide recommendations tailored to a specific type of project (for example, recommendations on school construction on a version of <em>Think Hazard!</em> that is dedicated to the education sector). If you see a need for a specific type of project, please get in touch using the ‘contact us’ page to discuss development.
+          This initial version of <em>ThinkHazard!</em> is designed to be generic and not to provide specific recommendations for different sectors. Instead, we encourage partners who work in sectoral areas to work with us to produce sector (or project) specific versions of this tool, which would provide recommendations tailored to a specific type of project (for example, recommendations on school construction on a version of <em>ThinkHazard!</em> that is dedicated to the education sector). THe code is open-source, so the tool structure can be reproduced for different projects or purposes. If you see a need for a specific type of project, please get in touch using the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to discuss development.
           </dd>
         </dl>
         <dl>
@@ -48,15 +56,23 @@
           In which languages is the tool available?
           </dt>
           <dd>
-          <em>Think Hazard!</em> is currently only available in English; however, in future development we would like to add additional language functionality to <em>Think Hazard!</em>. Please use ‘contact us’ to tell us which other languages would be helpful for users of <em>Think Hazard!</em>.
+          <em>ThinkHazard!</em> is currently only available in English; however, in future development we would like to add additional language functionality to <em>ThinkHazard!</em>. Please use <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> to tell us which other languages would be helpful for users of <em>ThinkHazard!</em>.
           </dd>
         </dl>
         <dl>
           <dt>
-          Can I contribute data to the tool?
+          I have useful hazard data - how can I contribute data to the tool?
           </dt>
           <dd>
-          Yes! We encourage all owners and developers of hazard data to share those data for use in <em>Think Hazard!</em>. If the dataset that you provide is used in the analysis of hazard in a project area, your institution will be credited as the data source with a weblink provided directly to your institution. Please use ‘contact us’ to let us know what datasets you might be willing to contribute, and we’ll get in touch with you directly to discuss further.
+          We encourage all owners and developers of hazard data to share those data for use in <em>ThinkHazard!</em>. If the dataset that you provide is used in the analysis of hazard in a project area, your institution will be credited as the data source with a weblink provided directly to your institution. Please use the user feedback form to let us know what datasets you would be able to contribute, and we’ll get in touch directly to discuss further.
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          I have useful additional information - how can I contribute data to the tool?
+          </dt>
+          <dd>
+          We encourage all owners and developers of hazard data to share those data for use in <em>ThinkHazard!</em>. If the dataset that you provide is used in the analysis of hazard in a project area, your institution will be credited as the data source with a weblink provided directly to your institution. Please use the user feedback form to let us know what datasets you might be willing to contribute, and we’ll get in touch with you directly to discuss further.
           </dd>
         </dl>
         <dl>
@@ -64,7 +80,7 @@
           Can I suggest additional recommendations or changes to some recommendations?
           </dt>
           <dd>
-          Yes! We encourage all users to provide their feedback on the recommendations given in <em>Think Hazard!</em>. Please use the ‘contact us’ page to let us know, and we’ll get in touch to discuss your suggestions further.
+          We encourage all users to provide their feedback on the recommendations given in <em>ThinkHazard!</em>. Please use the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to let us know, and we’ll get in touch to discuss your suggestions further.
           </dd>
         </dl>
         <dl>
@@ -72,7 +88,7 @@
           The hazard data seems to contradict other data I have seen or used. Why is this?
           </dt>
           <dd>
-          <em>Think Hazard!</em> uses a variety of sources of hazard data and the data source is provided on the map interface for each hazard. Some datasets are global and therefore are developed at a coarser resolution with a variety of assumptions. This may not be consistent with higher resolution or more detailed data available at the national or local level. Where local data has been provided for use within <em>Think Hazard!</em>, it will be shown. We encourage all users to provide their feedback on hazard data and to highlight where higher resolution or more detailed hazard data is available. Please use the ‘contact us’ page to let us know, and we’ll get in touch to discuss further.
+          <em>ThinkHazard!</em> uses a variety of sources of hazard data and the data source is provided on the map interface for each hazard. Some datasets are global and therefore are developed at a coarser resolution with a variety of assumptions. This may not be consistent with higher resolution or more detailed data available at the national or local level. Where local data has been provided for use within <em>ThinkHazard!</em>, it will be shown. We encourage all users to provide their feedback on hazard data and to highlight where higher resolution or more detailed hazard data is available. Please use the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to let us know, and we’ll get in touch to discuss further.
           </dd>
         </dl>
         <dl>
@@ -80,15 +96,47 @@
           How do you decide which hazard data to use for hazard levels?
           </dt>
           <dd>
-          Where multiple hazard datasets are available for a single location and hazard, <em>Think Hazard!</em> uses a decision tree to decide which dataset should be used. Submitted hazard data is reviewed by GFDRR hazard and risk specialists. A rating is assigned on the basis of age, methodology used, assumptions, and resolution of the data. Data with a higher rating is shown as a preference to users of <em>Think Hazard!</em>.
+          Where multiple hazard datasets are available for a single location and hazard, <em>ThinkHazard!</em> uses a decision tree to decide which dataset should be used. Submitted hazard data is reviewed by GFDRR hazard and risk specialists. A rating is assigned on the basis of age, methodology used, assumptions, and resolution of the data. Data with a higher rating is shown as a preference to users of <em>ThinkHazard!</em>.
           </dd>
         </dl>
         <dl>
           <dt>
-          Is <em>Think Hazard!</em> open-source?
+          Is <em>ThinkHazard!</em> open-source?
           </dt>
           <dd>
-          <em>Think Hazard!</em> has been designed as open-source from the start, with the code for <em>Think Hazard!</em> available on GitHub at <a href="https://github.com/GFDRR/thinkhazard" target="_blank">https://github.com/GFDRR/thinkhazard</a>. Open-source technology means that partners can easily adapt <em>Think Hazard!</em>  for their own use and to jointly contribute to the ongoing development of <em>Think Hazard!</em> into the future.
+          <em>ThinkHazard!</em> has been designed as open-source from the start, with the code for <em>ThinkHazard!</em> available on GitHub at https://github.com/GFDRR/thinkhazard. Open-source technology means that partners can easily adapt <em>ThinkHazard!</em>  for their own use and to jointly contribute to the ongoing development of <em>ThinkHazard!</em> into the future.
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          How can I report a bug or an error in data or recommendations?
+          </dt>
+          <dd>
+          A user feedback form is available on each page after you have searched a location. Please complete a feedback form on the page that you spot the issue. We will then endeavour to fix the problem.
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          Where can I find more information about the methods used in <em>ThinkHazard!</em>?
+          </dt>
+          <dd>
+          You can find the methodology document at <a href="About page" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/about</a>
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          What hazard data are used in <em>ThinkHazard!</em>, and can I download it for use elsewhere?
+          </dt>
+          <dd>
+          The data source used to produce the hazard levels is listed beneath the map, on the hazard specific recommendations page. By clicking on the data source name, you can download any data that are openly available. All data are stored on the Innovation Labs Geonode, at <a href="https://github.com/GFDRR/thinkhazard" target="_blank">https://github.com/GFDRR/thinkhazard</a>.Data with commercial limitations on sharing are not available to download.
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          What do the hazard levels mean?
+          </dt>
+          <dd>
+          Hazard level is calculated according the frequency, at which that hazard is expected to occur with a damaging level of intensity. For each hazard we have set an intensity threshold, above which the intensity parameter is considered to be able to cause damage to a development project of undefined type. 
           </dd>
         </dl>
       </div>


### PR DESCRIPTION
Added several new FAQs, edited some existing (including removing space in Think Hazard!, and adding links to 'contact us' page - these are placeholders taking user to FAQ page). TO BE UPDATED when Contact Us page is active.