### PR TITLE
Handle metadata changes in harvesting

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -23,7 +23,6 @@ import datetime
 from sqlalchemy import (
     Boolean,
     Column,
-    Date,
     DateTime,
     ForeignKey,
     inspect,
@@ -344,10 +343,10 @@ class HazardSet(Base):
     local = Column(Boolean)
     # date the data was last updated (defaults to created):
     # this value comes from the linked layers
-    data_lastupdated_date = Column(Date, nullable=False)
+    data_lastupdated_date = Column(DateTime)
     # date the metadata was last updated (defaults to created):
     # this value comes from the linked layers
-    metadata_lastupdated_date = Column(Date, nullable=False)
+    metadata_lastupdated_date = Column(DateTime)
     # quality rating for the hazard calculation method
     # ranges from 0 (bad) to 10 (excellent).
     # this value comes from the linked layers


### PR DESCRIPTION
This resets the `downloaded`, `complete` and `processed` statuses when needed as metadata changes.