### PR TITLE
Prevent pyramid from failing in modwsgi

### DIFF
--- a/thinkhazard/processing/__init__.py
+++ b/thinkhazard/processing/__init__.py
@@ -26,7 +26,8 @@ from .. import load_local_settings
 
 
 def load_settings():
-    settings = get_appsettings('development.ini')
+    settings = get_appsettings(os.path.join(os.path.dirname(__file__),
+                                            '../../development.ini'))
 
     root_folder = os.path.join(os.path.dirname(__file__), '..', '..')
     main_settings_path = os.path.join(root_folder,


### PR DESCRIPTION
When loading settings for the processing scripts

Without this code change, the pyramid application is failing in modwsgi. It fails by trying to open "/var/www/development.ini" which doesn't exist.

The app settings may need some rework now that we only have one repository.
See https://github.com/GFDRR/thinkhazard/blob/master/thinkhazard/scripts/import.py#L66 for an example.