### PR TITLE
Show hazarset by admin div level 2 list

### DIFF
--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -47,6 +47,8 @@ def main(global_config, **settings):
     config.add_route('admin_technical_rec', '/admin/technical_rec')
     config.add_route('admin_technical_rec_new', '/admin/technical_rec/new')
     config.add_route('admin_technical_rec_edit', '/admin/technical_rec/{id}')
+    config.add_route('admin_admindiv_hazardsets',
+                     '/admin/admindiv_hazardsets/{hazardtype:([A-Z]{2})}')
     config.add_route('admin_hazardcategory',
                      '/admin/{hazard_type}/{hazard_level}')
 

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -163,12 +163,15 @@ class HazardCategoryAdministrativeDivisionAssociation(Base):
                                ForeignKey('hazardcategory.id'),
                                nullable=False, index=True)
     administrativedivision = relationship('AdministrativeDivision',
-                                          back_populates='hazardcategories')
+                                          back_populates='hazardcategories',
+                                          lazy='joined')
     hazardcategory = relationship('HazardCategory',
-                                  back_populates='administrativedivisions')
+                                  back_populates='administrativedivisions',
+                                  lazy='joined')
     hazardsets = relationship(
         'HazardSet',
-        secondary=hazardcategory_administrativedivision_hazardset_table)
+        secondary=hazardcategory_administrativedivision_hazardset_table,
+        lazy="joined")
 
 
 class HazardCategoryTechnicalRecommendationAssociation(Base):
@@ -243,7 +246,7 @@ class HazardCategory(Base):
                             nullable=False)
     general_recommendation = Column(Unicode, nullable=False)
 
-    hazardtype = relationship(HazardType)
+    hazardtype = relationship(HazardType, lazy="joined")
     hazardlevel = relationship(HazardLevel)
     administrativedivisions = relationship(
         'HazardCategoryAdministrativeDivisionAssociation',

--- a/thinkhazard/static/less/bootstrap.less
+++ b/thinkhazard/static/less/bootstrap.less
@@ -12,7 +12,7 @@
 @import "../../../node_modules/bootstrap/less/type.less";
 /*@import "../../../node_modules/bootstrap/less/code.less";*/
 @import "../../../node_modules/bootstrap/less/grid.less";
-/*@import "../../../node_modules/bootstrap/less/tables.less";*/
+@import "../../../node_modules/bootstrap/less/tables.less";
 @import "../../../node_modules/bootstrap/less/forms.less";
 @import "../../../node_modules/bootstrap/less/buttons.less";
 
@@ -24,7 +24,7 @@
 @import "../../../node_modules/bootstrap/less/navs.less";
 @import "../../../node_modules/bootstrap/less/navbar.less";
 /*@import "../../../node_modules/bootstrap/less/breadcrumbs.less";*/
-/*@import "../../../node_modules/bootstrap/less/pagination.less";*/
+@import "../../../node_modules/bootstrap/less/pagination.less";
 /*@import "../../../node_modules/bootstrap/less/pager.less";*/
 /*@import "../../../node_modules/bootstrap/less/labels.less";*/
 /*@import "../../../node_modules/bootstrap/less/badges.less";*/

--- a/thinkhazard/templates/admin/admindiv_hazardsets.jinja2
+++ b/thinkhazard/templates/admin/admindiv_hazardsets.jinja2
@@ -1,0 +1,40 @@
+{% extends "base.jinja2" %}
+
+{% from 'common.jinja2' import navbar %}
+
+{% block name %}admin{% endblock %}
+
+{% block content %}
+  {{ navbar(request) }}
+  <script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.2/angular.js"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ng-table/1.0.0-beta.9/ng-table.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ng-table/1.0.0-beta.9/ng-table.min.js"></script>
+  <div class="container" ng-app="myApp" ng-controller="MainCtrl as ctrl">
+    <table ng-table="ctrl.data" class="table table-condensed" show-filter="true">
+      <tr ng-repeat="row in $data">
+        <td sortable"'code'" title="'Code'">
+          {% raw %}
+          {{row.code}}
+          {% endraw %}
+        </td>
+        <td filter="{ name: 'text'}" sortable="'name'" title="'Name'">
+          {% raw %}
+          {{row.name}}
+          {% endraw %}
+        </td>
+        <td filter="{ hazardset: 'text'}" sortable="'hazarset'" title="'HazardSet'">
+          {% raw %}
+            {{row.hazardset}}
+          {% endraw %}
+        </td>
+      </tr>
+    </table>
+  </div>
+  <script>
+    var myApp = angular.module('myApp', ['ngTable']);
+    myApp.controller('MainCtrl', function(NgTableParams) {
+      var data = {{data}};
+      this.data = new NgTableParams({ }, {dataset: data});
+    });
+  </script>
+{% endblock %}

--- a/thinkhazard/templates/admin/hazardsets.jinja2
+++ b/thinkhazard/templates/admin/hazardsets.jinja2
@@ -12,7 +12,7 @@
         text-decoration: line-through;
       }
     </style>
-    <table class="table">
+    <table class="table table-condensed">
       <tr>
         <th></th>
         <th>Hazard Type</th>


### PR DESCRIPTION
With this pull request we can see the list of administrative divisions and the corresponding hazard set that was chosen (via decision tree) for a given hazard type.
Example : http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/pierre/wsgi/hazardsets/FL

Fixes #419.