### PR TITLE
Fix ProcessException so that message appears in stack trace. Fix #402

### DIFF
--- a/thinkhazard/processing/processing.py
+++ b/thinkhazard/processing/processing.py
@@ -55,8 +55,8 @@ logger.setLevel(logging.DEBUG)
 
 
 class ProcessException(Exception):
-    def __init__(self, message):
-        self.message = message
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
 
 
 def process(hazardset_id=None, force=False, dry_run=False):


### PR DESCRIPTION
Now we get this for exemple:
```
INFO - EQ-GLOBAL-GAR15
INFO -   Cleaning previous outputs
INFO -   Opening raster files
INFO -   Iterating over 926 administrative divisions
INFO -   Closing raster files
ERROR - Traceback (most recent call last):
  File "/srv/home/amorvan/thinkhazard/thinkhazard/processing/processing.py", line 75, in process
    process_hazardset(id[0], force=force)
  File "/srv/home/amorvan/thinkhazard/thinkhazard/processing/processing.py", line 147, in process_hazardset
    outputs = create_outputs(hazardset, layers, readers)
  File "/srv/home/amorvan/thinkhazard/thinkhazard/processing/processing.py", line 219, in create_outputs
    readers, shape)
  File "/srv/home/amorvan/thinkhazard/thinkhazard/processing/processing.py", line 314, in notpreprocessed_hazardlevel
    layer.hazardunit))
ProcessException: No threshold found for EQ global HIG PGA-gal
```