### PR TITLE
Add basic authentification for admin ui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ LESS_FILES = $(shell find thinkhazard/static/less -type f -name '*.less' 2> /dev
 JS_FILES = $(shell find thinkhazard/static/js -type f -name '*.js' 2> /dev/null)
 PY_FILES = $(shell find thinkhazard -type f -name '*.py' 2> /dev/null)
 INSTANCEID ?= main
+AUTHUSERFILE ?= /var/www/vhosts/wb-thinkhazard/conf/.htpasswd
 DATA ?= world
 
 .PHONY: all
@@ -207,6 +208,7 @@ thinkhazard/static/build/%.css: $(LESS_FILES) .build/node_modules.timestamp
 .build/apache-%.conf: apache.conf .build/venv
 	sed -e 's#{{PYTHONPATH}}#$(shell .build/venv/bin/python -c "import sys; print(sys.path[-1])")#' \
 		-e 's#{{INSTANCEID}}#$(INSTANCEID)#g' \
+		-e 's#{{AUTHUSERFILE}}#$(AUTHUSERFILE)#g' \
 		-e 's#{{WSGISCRIPT}}#$(abspath .build/thinkhazard-$*.wsgi)#' $< > $@
 
 .PHONY: clean

--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,24 @@ you can set ``INSTANCEID`` on the ``make modwsgi`` command line. For example::
 
 With this the application location will be ``/elemoine/wsgi``.
 
+Configure admin username/password
+---------------------------------
+
+By default, the admin interface authentification file is
+``/var/www/vhosts/wb-thinkhazard/conf/.htpasswd``. To change the location you
+can set ``AUTHUSERFILE`` on the ``make modwsgi`` command line.
+
+To create a authentification file ``.htpassword`` with ``admin`` as the initial
+user ::
+
+    $ htpasswd -c .htpassword username
+
+It will prompt for the password.
+
+Add or modify ``username2`` in the password file ``.htpassword``::
+
+   $ htpasswd .htpassword username2
+
 Use ``local.ini``
 =================
 

--- a/apache.conf
+++ b/apache.conf
@@ -9,3 +9,13 @@ WSGIScriptAlias /{{INSTANCEID}}/wsgi {{WSGISCRIPT}}
     WSGIProcessGroup thinkhazard:{{INSTANCEID}}
     WSGIApplicationGroup %{GLOBAL}
 </Location>
+
+<Location /amorvan/wsgi/admin>
+    Order allow,deny
+    Allow from all
+    Require valid-user
+    Satisfy All
+    AuthType Basic
+    AuthName "Authentication Required"
+    AuthUserFile {{AUTHUSERFILE}}
+</Location>


### PR DESCRIPTION
Note that with this method, authentification is needed only with WSGI, not for tests.