### PR TITLE
Added geonode regions of the world to the csv. This fixes #441

### DIFF
--- a/data/geonode_regions_to_administrative_divisions_code.csv
+++ b/data/geonode_regions_to_administrative_divisions_code.csv
@@ -232,3 +232,238 @@
 "Yemen",251,269
 "Zambia",252,270
 "Zimbabwe",253,271
+"North America",2,46
+"West Africa",13,214
+"Pacific",256,83
+"Europe",5,104
+"Central Asia",8,250
+"Southern Africa",14,207
+"Europe",5,2647
+"Europe",5,147
+"Caribbean",255,210
+"East Africa",12,79
+"Caribbean",255,14
+"South Asia",9,231
+"Southern Africa",14,235
+"Europe",5,234
+"South America",4,12
+"South America",4,33
+"West Africa",13,45
+"West Africa",13,42
+"West Africa",13,94
+"Middle East",15,215
+"West Africa",13,47
+"Pacific",256,185
+"Europe",5,224
+"Central America",3,103
+"Europe",5,34
+"Middle East",15,137
+"Europe",5,204
+"Middle East",15,130
+"Caribbean",255,71
+"West Africa",13,144
+"South Asia",9,154
+"South Asia",9,188
+"Middle East",15,187
+"Europe",5,128
+"Caribbean",255,258
+"Europe",5,3
+"West Africa",13,89
+"Southeast Asia",7,44
+"Europe",5,84
+"Europe",5,166
+"Pacific",256,179
+"Middle East",15,269
+"Europe",5,69
+"Caribbean",255,123
+"North America",2,98
+"Pacific",256,212
+"East Asia",258,149
+"Pacific",256,184
+"Middle East",15,255
+"Pacific",256,101
+"South Asia",9,115
+"Europe",5,19
+"Southern Africa",14,142
+"Caribbean",255,211
+"East Africa",12,133
+"Central Asia",8,239
+"Europe",5,249
+"Central Asia",8,1
+"Pacific",256,163
+"South Asia",9,23
+"West Africa",13,159
+"Pacific",256,225
+"Southeast Asia",7,264
+"Caribbean",255,209
+"Europe",5,113
+"Europe",5,213
+"Europe",5,64
+"East Asia",258,167
+"Europe",5,85
+"Middle East",15,238
+"Caribbean",255,30
+"Europe",5,223
+"East Africa",12,226
+"South America",4,195
+"Pacific",256,262
+"Pacific",256,173
+"Europe",5,186
+"West Africa",13,66
+"Pacific",256,60
+"West Africa",13,29
+"North Africa",11,145
+"Caribbean",255,63
+"Middle East",15,117
+"North America",2,259
+"Caribbean",255,208
+"West Africa",13,243
+"East Asia",258,147295
+"Europe",5,13
+"East Asia",258,202
+"Caribbean",255,72
+"Europe",5,254
+"Middle East",15,21
+"Pacific",256,245
+"Caribbean",255,168
+"North Africa",11,268
+"Caribbean",255,48
+"Central Africa",257,49
+"Pacific",256,178
+"East Africa",12,160
+"Europe",5,146
+"Pacific",256,17
+"Caribbean",255,39
+"Europe",5,241
+"West Africa",13,155
+"Europe",5,236
+"Europe",5,41
+"Europe",5,203
+"West Africa",13,8
+"Central Africa",257,50
+"Southern Africa",14,227
+"Pacific",256,244
+"Central America",3,180
+"South America",4,81
+"Middle East",15,201
+"Southeast Asia",7,153
+"West Africa",13,217
+"East Africa",12,170
+"East Africa",12,253
+"East Asia",258,126
+"West Africa",13,181
+"Europe",5,120
+"South America",4,37
+"Pacific",256,197
+"West Africa",13,106
+"Central America",3,191
+"Europe",5,165
+"Central America",3,61
+"Europe",5,148
+"Pacific",256,5
+"Caribbean",255,20
+"Europe",5,95
+"Europe",5,119
+"Pacific",256,189
+"West Africa",13,182
+"South America",4,73
+"Europe",5,65
+"Europe",5,26
+"North Africa",11,4
+"Central America",3,75
+"Pacific",256,252
+"Europe",5,27
+"Pacific",256,157
+"South America",4,51
+"Caribbean",255,200
+"Caribbean",255,176
+"Southeast Asia",7,240
+"Caribbean",255,108
+"Central America",3,28
+"East Asia",258,33364
+"West Africa",13,221
+"Europe",5,92
+"Southeast Asia",7,139
+"West Africa",13,90
+"Southeast Asia",7,196
+"North Africa",11,169
+"Southern Africa",14,172
+"Pacific",256,87
+"West Africa",13,105
+"East Africa",12,257
+"Europe",5,237
+"Caribbean",255,99
+"Pacific",256,266
+"South America",4,263
+"East Africa",12,220
+"Europe",5,199
+"Europe",5,78
+"South America",4,260
+"West Africa",13,76
+"Middle East",15,141
+"Central Asia",8,261
+"North Africa",11,248
+"East Africa",12,70
+"East Africa",12,205
+"Caribbean",255,11
+"Europe",5,229
+"South America",4,57
+"East Africa",12,206
+"East Africa",12,43
+"Caribbean",255,251
+"Caribbean",255,24
+"East Africa",12,150
+"Europe",5,122
+"South Asia",9,31
+"North Africa",11,6
+"Europe",5,2648
+"South Asia",9,175
+"Pacific",256,135
+"Europe",5,156
+"Southeast Asia",7,40
+"Central Africa",257,68
+"Europe",5,177
+"Europe",5,256
+"South America",4,233
+"Caribbean",255,9
+"Europe",5,110
+"Middle East",15,121
+"Southeast Asia",7,116
+"Europe",5,114
+"Southern Africa",14,270
+"Europe",5,18
+"Pacific",256,192
+"East Africa",12,152
+"Southern Africa",14,271
+"Europe",5,93
+"Middle East",15,91
+"Caribbean",255,158
+"Central Asia",8,132
+"Europe",5,198
+"East Africa",12,77
+"Central Asia",8,138
+"East Africa",12,161
+"Middle East",15,118
+"North America",2,162
+"Europe",5,7
+"Caribbean",255,246
+"Europe",5,140
+"North Africa",11,74
+"South America",4,107
+"Europe",5,62
+"Caribbean",255,100
+"Central America",3,111
+"Southeast Asia",7,171
+"North Africa",11,40765
+"Europe",5,82
+"Southeast Asia",7,222
+"East Asia",258,67
+"East Africa",12,58
+"Southeast Asia",7,242
+"Global",1,10
+"Central Africa",257,59
+"Europe",5,97
+"South America",4,194
+"South America",4,86
+"Southern Africa",14,35
+"Pacific",256,183


### PR DESCRIPTION
Still missing 4 regions: Channel islands, Aland islands, Saint-Barthelemey and Saint Martin. 