### PR TITLE
Redirect to technical recommendations after form submit

### DIFF
--- a/thinkhazard/views/admin.py
+++ b/thinkhazard/views/admin.py
@@ -339,4 +339,4 @@ def climate_rec_process(request, obj):
 
         DBSession.flush()
         return HTTPFound(request.route_url('admin_climate_rec_edit',
-                                           id=obj.id))
+                         id=obj.hazardtype.mnemonic))

--- a/thinkhazard/views/admin.py
+++ b/thinkhazard/views/admin.py
@@ -174,8 +174,7 @@ def technical_rec_process(request, obj):
                 obj.hazardcategory_associations.append(record)
 
         DBSession.flush()
-        return HTTPFound(request.route_url('admin_technical_rec_edit',
-                                           id=obj.id))
+        return HTTPFound(request.route_url('admin_technical_rec'))
 
 
 @view_config(route_name='admin_hazardsets',


### PR DESCRIPTION
When a user edits either a technical or climate change recommendation, the page reloads after form submit. Then the user is tempted to use the back button on his browser to get back to the list of recommendations. It may result (in Firefox for example) to showing a list which is not up-to-date, and thus confusion about whether the change has been taken into account or not.
This pull request fixes this behavior by redirecting the user directly to the list after form submit.