### PR TITLE
More GeoNode Regions to GAUL relations

### DIFF
--- a/data/geonode_regions_to_administrative_divisions_code.csv
+++ b/data/geonode_regions_to_administrative_divisions_code.csv
@@ -232,238 +232,512 @@
 "Yemen",251,269
 "Zambia",252,270
 "Zimbabwe",253,271
-"North America",2,46
-"West Africa",13,214
-"Pacific",256,83
-"Europe",5,104
+"Caribbean",255,210
+"Caribbean",255,14
+"Caribbean",255,71
+"Caribbean",255,258
+"Caribbean",255,123
+"Caribbean",255,211
+"Caribbean",255,209
+"Caribbean",255,30
+"Caribbean",255,63
+"Caribbean",255,208
+"Caribbean",255,72
+"Caribbean",255,168
+"Caribbean",255,48
+"Caribbean",255,39
+"Caribbean",255,20
+"Caribbean",255,200
+"Caribbean",255,176
+"Caribbean",255,108
+"Caribbean",255,99
+"Caribbean",255,11
+"Caribbean",255,251
+"Caribbean",255,24
+"Caribbean",255,9
+"Caribbean",255,158
+"Caribbean",255,246
+"Caribbean",255,100
+"Central Africa",257,49
+"Central Africa",257,50
+"Central Africa",257,68
+"Central Africa",257,59
+"Central America",3,103
+"Central America",3,180
+"Central America",3,191
+"Central America",3,61
+"Central America",3,75
+"Central America",3,28
+"Central America",3,111
 "Central Asia",8,250
-"Southern Africa",14,207
+"Central Asia",8,239
+"Central Asia",8,1
+"Central Asia",8,261
+"Central Asia",8,132
+"Central Asia",8,138
+"East Africa",12,79
+"East Africa",12,133
+"East Africa",12,226
+"East Africa",12,160
+"East Africa",12,170
+"East Africa",12,253
+"East Africa",12,257
+"East Africa",12,220
+"East Africa",12,70
+"East Africa",12,205
+"East Africa",12,206
+"East Africa",12,43
+"East Africa",12,150
+"East Africa",12,152
+"East Africa",12,77
+"East Africa",12,161
+"East Africa",12,58
+"East Asia",258,149
+"East Asia",258,167
+"East Asia",258,147295
+"East Asia",258,202
+"East Asia",258,126
+"East Asia",258,33364
+"East Asia",258,67
+"Europe",5,104
 "Europe",5,2647
 "Europe",5,147
-"Caribbean",255,210
-"East Africa",12,79
-"Caribbean",255,14
-"South Asia",9,231
-"Southern Africa",14,235
 "Europe",5,234
-"South America",4,12
-"South America",4,33
-"West Africa",13,45
-"West Africa",13,42
-"West Africa",13,94
-"Middle East",15,215
-"West Africa",13,47
-"Pacific",256,185
 "Europe",5,224
-"Central America",3,103
 "Europe",5,34
-"Middle East",15,137
 "Europe",5,204
-"Middle East",15,130
-"Caribbean",255,71
-"West Africa",13,144
-"South Asia",9,154
-"South Asia",9,188
-"Middle East",15,187
 "Europe",5,128
-"Caribbean",255,258
 "Europe",5,3
-"West Africa",13,89
-"Southeast Asia",7,44
 "Europe",5,84
 "Europe",5,166
-"Pacific",256,179
-"Middle East",15,269
 "Europe",5,69
-"Caribbean",255,123
-"North America",2,98
-"Pacific",256,212
-"East Asia",258,149
-"Pacific",256,184
-"Middle East",15,255
-"Pacific",256,101
-"South Asia",9,115
 "Europe",5,19
-"Southern Africa",14,142
-"Caribbean",255,211
-"East Africa",12,133
-"Central Asia",8,239
 "Europe",5,249
-"Central Asia",8,1
-"Pacific",256,163
-"South Asia",9,23
-"West Africa",13,159
-"Pacific",256,225
-"Southeast Asia",7,264
-"Caribbean",255,209
 "Europe",5,113
 "Europe",5,213
 "Europe",5,64
-"East Asia",258,167
 "Europe",5,85
-"Middle East",15,238
-"Caribbean",255,30
 "Europe",5,223
-"East Africa",12,226
-"South America",4,195
-"Pacific",256,262
-"Pacific",256,173
 "Europe",5,186
-"West Africa",13,66
-"Pacific",256,60
-"West Africa",13,29
-"North Africa",11,145
-"Caribbean",255,63
-"Middle East",15,117
-"North America",2,259
-"Caribbean",255,208
-"West Africa",13,243
-"East Asia",258,147295
 "Europe",5,13
-"East Asia",258,202
-"Caribbean",255,72
 "Europe",5,254
-"Middle East",15,21
-"Pacific",256,245
-"Caribbean",255,168
-"North Africa",11,268
-"Caribbean",255,48
-"Central Africa",257,49
-"Pacific",256,178
-"East Africa",12,160
 "Europe",5,146
-"Pacific",256,17
-"Caribbean",255,39
 "Europe",5,241
-"West Africa",13,155
 "Europe",5,236
 "Europe",5,41
 "Europe",5,203
-"West Africa",13,8
-"Central Africa",257,50
-"Southern Africa",14,227
-"Pacific",256,244
-"Central America",3,180
-"South America",4,81
-"Middle East",15,201
-"Southeast Asia",7,153
-"West Africa",13,217
-"East Africa",12,170
-"East Africa",12,253
-"East Asia",258,126
-"West Africa",13,181
 "Europe",5,120
-"South America",4,37
-"Pacific",256,197
-"West Africa",13,106
-"Central America",3,191
 "Europe",5,165
-"Central America",3,61
 "Europe",5,148
-"Pacific",256,5
-"Caribbean",255,20
 "Europe",5,95
 "Europe",5,119
-"Pacific",256,189
-"West Africa",13,182
-"South America",4,73
 "Europe",5,65
 "Europe",5,26
-"North Africa",11,4
-"Central America",3,75
-"Pacific",256,252
 "Europe",5,27
-"Pacific",256,157
-"South America",4,51
-"Caribbean",255,200
-"Caribbean",255,176
-"Southeast Asia",7,240
-"Caribbean",255,108
-"Central America",3,28
-"East Asia",258,33364
-"West Africa",13,221
 "Europe",5,92
-"Southeast Asia",7,139
-"West Africa",13,90
-"Southeast Asia",7,196
-"North Africa",11,169
-"Southern Africa",14,172
-"Pacific",256,87
-"West Africa",13,105
-"East Africa",12,257
 "Europe",5,237
-"Caribbean",255,99
-"Pacific",256,266
-"South America",4,263
-"East Africa",12,220
 "Europe",5,199
 "Europe",5,78
-"South America",4,260
-"West Africa",13,76
-"Middle East",15,141
-"Central Asia",8,261
-"North Africa",11,248
-"East Africa",12,70
-"East Africa",12,205
-"Caribbean",255,11
 "Europe",5,229
-"South America",4,57
-"East Africa",12,206
-"East Africa",12,43
-"Caribbean",255,251
-"Caribbean",255,24
-"East Africa",12,150
 "Europe",5,122
-"South Asia",9,31
-"North Africa",11,6
 "Europe",5,2648
-"South Asia",9,175
-"Pacific",256,135
 "Europe",5,156
-"Southeast Asia",7,40
-"Central Africa",257,68
 "Europe",5,177
 "Europe",5,256
-"South America",4,233
-"Caribbean",255,9
 "Europe",5,110
-"Middle East",15,121
-"Southeast Asia",7,116
 "Europe",5,114
-"Southern Africa",14,270
 "Europe",5,18
-"Pacific",256,192
-"East Africa",12,152
-"Southern Africa",14,271
 "Europe",5,93
-"Middle East",15,91
-"Caribbean",255,158
-"Central Asia",8,132
 "Europe",5,198
-"East Africa",12,77
-"Central Asia",8,138
-"East Africa",12,161
-"Middle East",15,118
-"North America",2,162
 "Europe",5,7
-"Caribbean",255,246
 "Europe",5,140
-"North Africa",11,74
-"South America",4,107
 "Europe",5,62
-"Caribbean",255,100
-"Central America",3,111
-"Southeast Asia",7,171
-"North Africa",11,40765
 "Europe",5,82
-"Southeast Asia",7,222
-"East Asia",258,67
-"East Africa",12,58
-"Southeast Asia",7,242
-"Global",1,10
-"Central Africa",257,59
 "Europe",5,97
+"Middle East",15,215
+"Middle East",15,137
+"Middle East",15,130
+"Middle East",15,187
+"Middle East",15,269
+"Middle East",15,255
+"Middle East",15,238
+"Middle East",15,117
+"Middle East",15,21
+"Middle East",15,201
+"Middle East",15,141
+"Middle East",15,121
+"Middle East",15,91
+"Middle East",15,118
+"North Africa",11,145
+"North Africa",11,268
+"North Africa",11,4
+"North Africa",11,169
+"North Africa",11,248
+"North Africa",11,6
+"North Africa",11,74
+"North Africa",11,40765
+"North America",2,46
+"North America",2,98
+"North America",2,259
+"North America",2,162
+"Pacific",256,83
+"Pacific",256,185
+"Pacific",256,179
+"Pacific",256,212
+"Pacific",256,184
+"Pacific",256,101
+"Pacific",256,163
+"Pacific",256,225
+"Pacific",256,262
+"Pacific",256,173
+"Pacific",256,60
+"Pacific",256,245
+"Pacific",256,178
+"Pacific",256,17
+"Pacific",256,244
+"Pacific",256,197
+"Pacific",256,5
+"Pacific",256,189
+"Pacific",256,252
+"Pacific",256,157
+"Pacific",256,87
+"Pacific",256,266
+"Pacific",256,135
+"Pacific",256,192
+"Pacific",256,183
+"South America",4,12
+"South America",4,33
+"South America",4,195
+"South America",4,81
+"South America",4,37
+"South America",4,73
+"South America",4,51
+"South America",4,263
+"South America",4,260
+"South America",4,57
+"South America",4,233
+"South America",4,107
 "South America",4,194
 "South America",4,86
+"South Asia",9,231
+"South Asia",9,154
+"South Asia",9,188
+"South Asia",9,115
+"South Asia",9,23
+"South Asia",9,31
+"South Asia",9,175
+"Southeast Asia",7,44
+"Southeast Asia",7,264
+"Southeast Asia",7,153
+"Southeast Asia",7,240
+"Southeast Asia",7,139
+"Southeast Asia",7,196
+"Southeast Asia",7,40
+"Southeast Asia",7,116
+"Southeast Asia",7,171
+"Southeast Asia",7,222
+"Southeast Asia",7,242
+"Southern Africa",14,207
+"Southern Africa",14,235
+"Southern Africa",14,142
+"Southern Africa",14,227
+"Southern Africa",14,172
+"Southern Africa",14,270
+"Southern Africa",14,271
 "Southern Africa",14,35
-"Pacific",256,183
+"West Africa",13,214
+"West Africa",13,45
+"West Africa",13,42
+"West Africa",13,94
+"West Africa",13,47
+"West Africa",13,144
+"West Africa",13,89
+"West Africa",13,159
+"West Africa",13,66
+"West Africa",13,29
+"West Africa",13,243
+"West Africa",13,155
+"West Africa",13,8
+"West Africa",13,217
+"West Africa",13,181
+"West Africa",13,106
+"West Africa",13,182
+"West Africa",13,221
+"West Africa",13,90
+"West Africa",13,105
+"West Africa",13,76
+"Global",1,46,"Canada"
+"Global",1,244,"Tokelau"
+"Global",1,87,"French Polynesia"
+"Global",1,183,"Niue"
+"Global",1,5,"American Samoa"
+"Global",1,265,"Wake Island"
+"Global",1,252,"Tuvalu"
+"Global",1,266,"Wallis and Futuna"
+"Global",1,197,"Pitcairn"
+"Global",1,60,"Cook Islands"
+"Global",1,245,"Tonga"
+"Global",1,212,"Samoa"
+"Global",1,135,"Kiribati"
+"Global",1,163,"Micronesia (Federated States of)"
+"Global",1,189,"Palau"
+"Global",1,173,"Nauru"
+"Global",1,157,"Marshall Islands"
+"Global",1,185,"Northern Mariana Islands"
+"Global",1,101,"Guam"
+"Global",1,83,"Fiji"
+"Global",1,178,"New Caledonia"
+"Global",1,225,"Solomon Islands"
+"Global",1,262,"Vanuatu"
+"Global",1,192,"Papua New Guinea"
+"Global",1,16,"Ashmore and Cartier Islands"
+"Global",1,17,"Australia"
+"Global",1,54,"Christmas Island"
+"Global",1,18,"Austria"
+"Global",1,27,"Belgium"
+"Global",1,237,"Switzerland"
+"Global",1,93,"Germany"
+"Global",1,85,"France"
+"Global",1,146,"Liechtenstein"
+"Global",1,148,"Luxembourg"
+"Global",1,177,"Netherlands"
+"Global",1,166,"Monaco"
+"Global",1,3,"Albania"
+"Global",1,7,"Andorra"
+"Global",1,74578,"Azores Islands"
+"Global",1,34,"Bosnia and Herzegovina"
+"Global",1,229,"Spain"
+"Global",1,95,"Gibraltar"
+"Global",1,2648,"Serbia"
+"Global",1,199,"Portugal"
+"Global",1,122,"Italy"
+"Global",1,97,"Greece"
+"Global",1,224,"Slovenia"
+"Global",1,213,"San Marino"
+"Global",1,140,"Latvia"
+"Global",1,147,"Lithuania"
+"Global",1,82,"Faroe Islands"
+"Global",1,236,"Sweden"
+"Global",1,104,"Guernsey"
+"Global",1,186,"Norway"
+"Global",1,120,"Isle of Man"
+"Global",1,41,"Bulgaria"
+"Global",1,223,"Slovakia"
+"Global",1,204,"Russian Federation"
+"Global",1,136,"Kuril islands"
+"Global",1,65,"Czech Republic"
+"Global",1,26,"Belarus"
+"Global",1,254,"Ukraine"
+"Global",1,203,"Romania"
+"Global",1,198,"Poland"
+"Global",1,113,"Hungary"
+"Global",1,165,"Moldova, Republic of"
+"Global",1,255,"United Arab Emirates"
+"Global",1,13,"Armenia"
+"Global",1,19,"Azerbaijan"
+"Global",1,21,"Bahrain"
+"Global",1,56,"Cocos (Keeling) Islands"
+"Global",1,179,"New Zealand"
+"Global",1,156,"Malta"
+"Global",1,62,"Croatia"
+"Global",1,110,"Holy See"
+"Global",1,2647,"Montenegro"
+"Global",1,241,"The former Yugoslav Republic of Macedonia"
+"Global",1,151,"Madeira Islands"
+"Global",1,69,"Denmark"
+"Global",1,78,"Estonia"
+"Global",1,84,"Finland"
+"Global",1,256,"U.K. of Great Britain and Northern Ireland"
+"Global",1,128,"Jersey"
+"Global",1,114,"Iceland"
+"Global",1,119,"Ireland"
+"Global",1,234,"Svalbard and Jan Mayen Islands"
+"Global",1,64,"Cyprus"
+"Global",1,92,"Georgia"
+"Global",1,121,"Israel"
+"Global",1,238,"Syrian Arab Republic"
+"Global",1,130,"Jordan"
+"Global",1,118,"Iraq"
+"Global",1,91,"Gaza Strip"
+"Global",1,269,"Yemen"
+"Global",1,249,"Turkey"
+"Global",1,215,"Saudi Arabia"
+"Global",1,201,"Qatar"
+"Global",1,141,"Lebanon"
+"Global",1,267,"West Bank"
+"Global",1,40781,"Jammu and Kashmir"
+"Global",1,117,"Iran  (Islamic Republic of)"
+"Global",1,115,"India"
+"Global",1,188,"Pakistan"
+"Global",1,175,"Nepal"
+"Global",1,154,"Maldives"
+"Global",1,242,"Timor-Leste"
+"Global",1,230,"Spratly Islands"
+"Global",1,222,"Singapore"
+"Global",1,239,"Tajikistan"
+"Global",1,261,"Uzbekistan"
+"Global",1,250,"Turkmenistan"
+"Global",1,36,"Bouvet Island"
+"Global",1,88,"French Southern and Antarctic Territories"
+"Global",1,109,"Heard Island and McDonald Islands"
+"Global",1,40,"Brunei Darussalam"
+"Global",1,240,"Thailand"
+"Global",1,153,"Malaysia"
+"Global",1,139,"Lao People's Democratic Republic"
+"Global",1,264,"Viet Nam"
+"Global",1,44,"Cambodia"
+"Global",1,171,"Myanmar"
+"Global",1,2,"Aksai Chin"
+"Global",1,52,"China/India"
+"Global",1,147295,"China"
+"Global",1,33364,"Hong Kong"
+"Global",1,67,"Dem People's Rep of Korea"
+"Global",1,218,"Senkaku Islands"
+"Global",1,193,"Paracel Islands"
+"Global",1,202,"Republic of Korea"
+"Global",1,147296,"Taiwan"
+"Global",1,167,"Mongolia"
+"Global",1,149,"Macau"
+"Global",1,132,"Kazakhstan"
+"Global",1,138,"Kyrgyzstan"
+"Global",1,12,"Argentina"
+"Global",1,33,"Bolivia"
+"Global",1,37,"Brazil"
+"Global",1,51,"Chile"
+"Global",1,228,"South Georgia and the South Sandwich Islands"
+"Global",1,195,"Peru"
+"Global",1,81,"Falkland Islands (Malvinas)"
+"Global",1,263,"Venezuela"
+"Global",1,260,"Uruguay"
+"Global",1,233,"Suriname"
+"Global",1,194,"Paraguay"
+"Global",1,86,"French Guiana"
+"Global",1,73,"Ecuador"
+"Global",1,107,"Guyana"
+"Global",1,57,"Colombia"
+"Global",1,22,"Baker Island"
+"Global",1,30,"Bermuda"
+"Global",1,112,"Howland Island"
+"Global",1,129,"Johnston Atoll"
+"Global",1,127,"Jarvis Island"
+"Global",1,134,"Kingman Reef"
+"Global",1,164,"Midway Island"
+"Global",1,190,"Palmyra Atoll"
+"Global",1,210,"Saint Pierre et Miquelon"
+"Global",1,259,"United States of America"
+"Global",1,28,"Belize"
+"Global",1,55,"Clipperton Island"
+"Global",1,61,"Costa Rica"
+"Global",1,103,"Guatemala"
+"Global",1,111,"Honduras"
+"Global",1,162,"Mexico"
+"Global",1,180,"Nicaragua"
+"Global",1,75,"El Salvador"
+"Global",1,191,"Panama"
+"Global",1,14,"Aruba"
+"Global",1,258,"United States Virgin Islands"
+"Global",1,200,"Puerto Rico"
+"Global",1,108,"Haiti"
+"Global",1,9,"Anguilla"
+"Global",1,100,"Guadeloupe"
+"Global",1,24,"Barbados"
+"Global",1,39,"British Virgin Islands"
+"Global",1,211,"Saint Vincent and the Grenadines"
+"Global",1,174,"Navassa Island"
+"Global",1,126,"Japan"
+"Global",1,216,"Scarborough Reef"
+"Global",1,98,"Greenland"
+"Global",1,209,"Saint Lucia"
+"Global",1,32,"Bird Island"
+"Global",1,20,"Bahamas"
+"Global",1,246,"Trinidad and Tobago"
+"Global",1,251,"Turks and Caicos islands"
+"Global",1,168,"Montserrat"
+"Global",1,155,"Mali"
+"Global",1,159,"Mauritania"
+"Global",1,181,"Niger"
+"Global",1,182,"Nigeria"
+"Global",1,217,"Senegal"
+"Global",1,221,"Sierra Leone"
+"Global",1,243,"Togo"
+"Global",1,207,"Saint Helena"
+"Global",1,35,"Botswana"
+"Global",1,227,"South Africa"
+"Global",1,142,"Lesotho"
+"Global",1,235,"Swaziland"
+"Global",1,184,"Norfolk Island"
+"Global",1,137,"Kuwait"
+"Global",1,187,"Oman"
+"Global",1,1,"Afghanistan"
+"Global",1,15,"Arunachal Pradesh"
+"Global",1,23,"Bangladesh"
+"Global",1,31,"Bhutan"
+"Global",1,231,"Sri Lanka"
+"Global",1,116,"Indonesia"
+"Global",1,196,"Philippines"
+"Global",1,208,"Saint Kitts and Nevis"
+"Global",1,123,"Jamaica"
+"Global",1,99,"Grenada"
+"Global",1,63,"Cuba"
+"Global",1,11,"Antigua and Barbuda"
+"Global",1,176,"Netherlands Antilles"
+"Global",1,48,"Cayman Islands"
+"Global",1,158,"Martinique"
+"Global",1,72,"Dominican Republic"
+"Global",1,71,"Dominica"
+"Global",1,29,"Benin"
+"Global",1,42,"Burkina Faso"
+"Global",1,66,"Côte d'Ivoire"
+"Global",1,47,"Cape Verde"
+"Global",1,94,"Ghana"
+"Global",1,106,"Guinea"
+"Global",1,90,"Gambia"
+"Global",1,105,"Guinea-Bissau"
+"Global",1,144,"Liberia"
+"Global",1,172,"Namibia"
+"Global",1,102,"Abyei"
+"Global",1,4,"Algeria"
+"Global",1,40765,"Egypt"
+"Global",1,268,"Western Sahara"
+"Global",1,248,"Tunisia"
+"Global",1,6,"Sudan"
+"Global",1,40762,"Ma'tan al-Sarra"
+"Global",1,145,"Libya"
+"Global",1,40760,"Hala'ib triangle"
+"Global",1,169,"Morocco"
+"Global",1,8,"Angola"
+"Global",1,49,"Central African Republic"
+"Global",1,45,"Cameroon"
+"Global",1,68,"Democratic Republic of the Congo"
+"Global",1,59,"Congo"
+"Global",1,214,"Sao Tome and Principe"
+"Global",1,50,"Chad"
+"Global",1,76,"Equatorial Guinea"
+"Global",1,89,"Gabon"
+"Global",1,43,"Burundi"
+"Global",1,25,"Bassas da India"
+"Global",1,38,"British Indian Ocean Territory"
+"Global",1,58,"Comoros"
+"Global",1,70,"Djibouti"
+"Global",1,77,"Eritrea"
+"Global",1,79,"Ethiopia"
+"Global",1,80,"Europa Island"
+"Global",1,96,"Glorioso Island"
+"Global",1,61013,"Ilemi triangle"
+"Global",1,131,"Juan de Nova Island"
+"Global",1,271,"Zimbabwe"
+"Global",1,253,"Uganda"
+"Global",1,257,"United Republic of Tanzania"
+"Global",1,247,"Tromelin Island"
+"Global",1,220,"Seychelles"
+"Global",1,74,"South Sudan"
+"Global",1,206,"Réunion"
+"Global",1,150,"Madagascar"
+"Global",1,133,"Kenya"
+"Global",1,270,"Zambia"
+"Global",1,226,"Somalia"
+"Global",1,205,"Rwanda"
+"Global",1,161,"Mayotte"
+"Global",1,152,"Malawi"
+"Global",1,160,"Mauritius"
+"Global",1,170,"Mozambique"

--- a/data/geonode_regions_to_administrative_divisions_code.csv
+++ b/data/geonode_regions_to_administrative_divisions_code.csv
@@ -232,3 +232,238 @@
 "Yemen",251,269
 "Zambia",252,270
 "Zimbabwe",253,271
+"North America",2,46
+"West Africa",13,214
+"Pacific",256,83
+"Europe",5,104
+"Central Asia",8,250
+"Southern Africa",14,207
+"Europe",5,2647
+"Europe",5,147
+"Caribbean",255,210
+"East Africa",12,79
+"Caribbean",255,14
+"South Asia",9,231
+"Southern Africa",14,235
+"Europe",5,234
+"South America",4,12
+"South America",4,33
+"West Africa",13,45
+"West Africa",13,42
+"West Africa",13,94
+"Middle East",15,215
+"West Africa",13,47
+"Pacific",256,185
+"Europe",5,224
+"Central America",3,103
+"Europe",5,34
+"Middle East",15,137
+"Europe",5,204
+"Middle East",15,130
+"Caribbean",255,71
+"West Africa",13,144
+"South Asia",9,154
+"South Asia",9,188
+"Middle East",15,187
+"Europe",5,128
+"Caribbean",255,258
+"Europe",5,3
+"West Africa",13,89
+"Southeast Asia",7,44
+"Europe",5,84
+"Europe",5,166
+"Pacific",256,179
+"Middle East",15,269
+"Europe",5,69
+"Caribbean",255,123
+"North America",2,98
+"Pacific",256,212
+"East Asia",258,149
+"Pacific",256,184
+"Middle East",15,255
+"Pacific",256,101
+"South Asia",9,115
+"Europe",5,19
+"Southern Africa",14,142
+"Caribbean",255,211
+"East Africa",12,133
+"Central Asia",8,239
+"Europe",5,249
+"Central Asia",8,1
+"Pacific",256,163
+"South Asia",9,23
+"West Africa",13,159
+"Pacific",256,225
+"Southeast Asia",7,264
+"Caribbean",255,209
+"Europe",5,113
+"Europe",5,213
+"Europe",5,64
+"East Asia",258,167
+"Europe",5,85
+"Middle East",15,238
+"Caribbean",255,30
+"Europe",5,223
+"East Africa",12,226
+"South America",4,195
+"Pacific",256,262
+"Pacific",256,173
+"Europe",5,186
+"West Africa",13,66
+"Pacific",256,60
+"West Africa",13,29
+"North Africa",11,145
+"Caribbean",255,63
+"Middle East",15,117
+"North America",2,259
+"Caribbean",255,208
+"West Africa",13,243
+"East Asia",258,147295
+"Europe",5,13
+"East Asia",258,202
+"Caribbean",255,72
+"Europe",5,254
+"Middle East",15,21
+"Pacific",256,245
+"Caribbean",255,168
+"North Africa",11,268
+"Caribbean",255,48
+"Central Africa",257,49
+"Pacific",256,178
+"East Africa",12,160
+"Europe",5,146
+"Pacific",256,17
+"Caribbean",255,39
+"Europe",5,241
+"West Africa",13,155
+"Europe",5,236
+"Europe",5,41
+"Europe",5,203
+"West Africa",13,8
+"Central Africa",257,50
+"Southern Africa",14,227
+"Pacific",256,244
+"Central America",3,180
+"South America",4,81
+"Middle East",15,201
+"Southeast Asia",7,153
+"West Africa",13,217
+"East Africa",12,170
+"East Africa",12,253
+"East Asia",258,126
+"West Africa",13,181
+"Europe",5,120
+"South America",4,37
+"Pacific",256,197
+"West Africa",13,106
+"Central America",3,191
+"Europe",5,165
+"Central America",3,61
+"Europe",5,148
+"Pacific",256,5
+"Caribbean",255,20
+"Europe",5,95
+"Europe",5,119
+"Pacific",256,189
+"West Africa",13,182
+"South America",4,73
+"Europe",5,65
+"Europe",5,26
+"North Africa",11,4
+"Central America",3,75
+"Pacific",256,252
+"Europe",5,27
+"Pacific",256,157
+"South America",4,51
+"Caribbean",255,200
+"Caribbean",255,176
+"Southeast Asia",7,240
+"Caribbean",255,108
+"Central America",3,28
+"East Asia",258,33364
+"West Africa",13,221
+"Europe",5,92
+"Southeast Asia",7,139
+"West Africa",13,90
+"Southeast Asia",7,196
+"North Africa",11,169
+"Southern Africa",14,172
+"Pacific",256,87
+"West Africa",13,105
+"East Africa",12,257
+"Europe",5,237
+"Caribbean",255,99
+"Pacific",256,266
+"South America",4,263
+"East Africa",12,220
+"Europe",5,199
+"Europe",5,78
+"South America",4,260
+"West Africa",13,76
+"Middle East",15,141
+"Central Asia",8,261
+"North Africa",11,248
+"East Africa",12,70
+"East Africa",12,205
+"Caribbean",255,11
+"Europe",5,229
+"South America",4,57
+"East Africa",12,206
+"East Africa",12,43
+"Caribbean",255,251
+"Caribbean",255,24
+"East Africa",12,150
+"Europe",5,122
+"South Asia",9,31
+"North Africa",11,6
+"Europe",5,2648
+"South Asia",9,175
+"Pacific",256,135
+"Europe",5,156
+"Southeast Asia",7,40
+"Central Africa",257,68
+"Europe",5,177
+"Europe",5,256
+"South America",4,233
+"Caribbean",255,9
+"Europe",5,110
+"Middle East",15,121
+"Southeast Asia",7,116
+"Europe",5,114
+"Southern Africa",14,270
+"Europe",5,18
+"Pacific",256,192
+"East Africa",12,152
+"Southern Africa",14,271
+"Europe",5,93
+"Middle East",15,91
+"Caribbean",255,158
+"Central Asia",8,132
+"Europe",5,198
+"East Africa",12,77
+"Central Asia",8,138
+"East Africa",12,161
+"Middle East",15,118
+"North America",2,162
+"Europe",5,7
+"Caribbean",255,246
+"Europe",5,140
+"North Africa",11,74
+"South America",4,107
+"Europe",5,62
+"Caribbean",255,100
+"Central America",3,111
+"Southeast Asia",7,171
+"North Africa",11,40765
+"Europe",5,82
+"Southeast Asia",7,222
+"East Asia",258,67
+"East Africa",12,58
+"Southeast Asia",7,242
+"Global",1,10
+"Central Africa",257,59
+"Europe",5,97
+"South America",4,194
+"South America",4,86
+"Southern Africa",14,35
+"Pacific",256,183


### PR DESCRIPTION
This PR builds upon https://github.com/GFDRR/thinkhazard/pull/447 but still misses the associations for GeoNode continents:
```
"Africa",10
"Americas",254
"Antarctica",16
"Asia",6
"Europe",5
"Middle East",15
"Pacific",256
```
