### PR TITLE
Change query to make it work with join_depth 2

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -250,7 +250,7 @@ class AdministrativeDivision(Base):
 
     leveltype = relationship(AdminLevelType)
     parent = relationship('AdministrativeDivision', uselist=False,
-                          lazy='joined', join_depth=3,
+                          lazy='joined', join_depth=2,
                           remote_side=code)
     hazardcategories = relationship(
         'HazardCategoryAdministrativeDivisionAssociation',


### PR DESCRIPTION
This PR supersedes #470.
When using a join_depth set to 2, which is better, the "administrative divisions hazardsets" in the admin UI doesn't do the job in a performant way.
With the current pull request, I fix the join_depth value, and change the query for admin page to work with the new value.
Please review.