### PR TITLE
Do not create apscheduler at import time

### DIFF
--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -15,13 +15,15 @@ from apscheduler.schedulers.background import BackgroundScheduler
 # background scheduler to run print jobs asynchronously. by default a thread
 # pool with 10 threads is used. to change the number of parallel print jobs,
 # see https://apscheduler.readthedocs.org/en/latest/userguide.html#configuring-the-scheduler  # noqa
-scheduler = BackgroundScheduler()
-scheduler.start()
+scheduler = None
 
 
 def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application.
     """
+    global scheduler
+    scheduler = BackgroundScheduler()
+    scheduler.start()
 
     load_local_settings(settings)
 


### PR DESCRIPTION
With scheduler created at import time, we have errors in processing scripts whereas is not used there. 