### PR TITLE
Updated to add a new FAQ

### DIFF
--- a/thinkhazard/templates/faq.jinja2
+++ b/thinkhazard/templates/faq.jinja2
@@ -30,7 +30,15 @@
           Where can I get a more specific version for my type of projects?
           </dt>
           <dd>
-          This initial version of <em>ThinkHazard!</em> is designed to be generic and not to provide specific recommendations for different sectors. Instead, we encourage partners who work in sectoral areas to work with us to produce sector (or project) specific versions of this tool, which would provide recommendations tailored to a specific type of project (for example, recommendations on school construction on a version of <em>ThinkHazard!</em> that is dedicated to the education sector). THe code is open-source, so the tool structure can be reproduced for different projects or purposes. If you see a need for a specific type of project, please get in touch using the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to discuss development.
+          This initial version of <em>ThinkHazard!</em> is designed to be generic and not to provide specific recommendations for different sectors. Instead, we encourage partners who work in sectoral areas to work with us to produce sector (or project) specific versions of this tool, which would provide recommendations tailored to a specific type of project (for example, recommendations on school construction on a version of <em>ThinkHazard!</em> that is dedicated to the education sector). THe code is open-source, so the tool structure can be reproduced for different projects or purposes. If you see a need for a specific type of project, please get in touch using the feedback button, available on every page, to discuss development.
+          </dd>
+        </dl>
+        <dl>
+          <dt>
+          How well do the results in <em>ThinkHazard!</em> align with expert opinion on the hazards in each country?
+          </dt>
+          <dd>
+          The <em>ThinkHazard!</em> team commissioned independent analysis of how well <em>ThinkHazard!</em> estimated the hazard for up to 77 developing countries around the world and the results can be seen <a href="here" target="_blank">https://drive.google.com/file/d/0B7QVzSpnQtEnR21vRkUtUVRoVHM/view?usp=sharing</a>. We recognise the importance of producing accurate results for our users so we are constantly looking for more accurate national and local datasets to supplement the global datasets that are predominantly used in the tool. If you are aware of additional hazard datasets please contact us via the feedback button, available on every page.
           </dd>
         </dl>
         <dl>
@@ -38,7 +46,7 @@
           In which languages is the tool available?
           </dt>
           <dd>
-          <em>ThinkHazard!</em> is currently only available in English; however, in future development we would like to add additional language functionality to <em>ThinkHazard!</em>. Please use <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> to tell us which other languages would be helpful for users of <em>ThinkHazard!</em>.
+          <em>ThinkHazard!</em> is currently only available in English; however, in future development we would like to add additional language functionality to <em>ThinkHazard!</em>. Please use the feedback button, available on every page, to tell us which other languages would be helpful for users of <em>ThinkHazard!</em>.
           </dd>
         </dl>
         <dl>
@@ -62,7 +70,7 @@
           Can I suggest additional recommendations or changes to some recommendations?
           </dt>
           <dd>
-          We encourage all users to provide their feedback on the recommendations given in <em>ThinkHazard!</em>. Please use the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to let us know, and we’ll get in touch to discuss your suggestions further.
+          We encourage all users to provide their feedback on the recommendations given in <em>ThinkHazard!</em>. Please use the feedback button, available on every page, to let us know, and we’ll get in touch to discuss your suggestions further.
           </dd>
         </dl>
         <dl>
@@ -70,7 +78,7 @@
           The hazard data seems to contradict other data I have seen or used. Why is this?
           </dt>
           <dd>
-          <em>ThinkHazard!</em> uses a variety of sources of hazard data and the data source is provided on the map interface for each hazard. Some datasets are global and therefore are developed at a coarser resolution with a variety of assumptions. This may not be consistent with higher resolution or more detailed data available at the national or local level. Where local data has been provided for use within <em>ThinkHazard!</em>, it will be shown. We encourage all users to provide their feedback on hazard data and to highlight where higher resolution or more detailed hazard data is available. Please use the <a href="contact us" target="_blank">http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/beta1/wsgi/faq</a> page to let us know, and we’ll get in touch to discuss further.
+          <em>ThinkHazard!</em> uses a variety of sources of hazard data and the data source is provided on the map interface for each hazard. Some datasets are global and therefore are developed at a coarser resolution with a variety of assumptions. This may not be consistent with higher resolution or more detailed data available at the national or local level. Where local data has been provided for use within <em>ThinkHazard!</em>, it will be shown. We encourage all users to provide their feedback on hazard data and to highlight where higher resolution or more detailed hazard data is available. Please use the feedback button, available on every page, to let us know, and we’ll get in touch to discuss further.
           </dd>
         </dl>
         <dl>
@@ -86,7 +94,7 @@
           Is <em>ThinkHazard!</em> open-source?
           </dt>
           <dd>
-          <em>ThinkHazard!</em> has been designed as open-source from the start, with the code for <em>ThinkHazard!</em> available on GitHub at https://github.com/GFDRR/thinkhazard. Open-source technology means that partners can easily adapt <em>ThinkHazard!</em>  for their own use and to jointly contribute to the ongoing development of <em>ThinkHazard!</em> into the future.
+          <em>ThinkHazard!</em> has been designed as open-source from the start, with the code for <em>ThinkHazard!</em> available on GitHub at <a href="https://github.com/GFDRR/thinkhazard" target="_blank">https://github.com/GFDRR/thinkhazard</a>. Open-source technology means that partners can easily adapt <em>ThinkHazard!</em>  for their own use and to jointly contribute to the ongoing development of <em>ThinkHazard!</em> into the future.
           </dd>
         </dl>
         <dl>


### PR DESCRIPTION
New FAQ directs users to a sheet that shows the comparison of hazard level given in ThinkHazard! and the comparison with expert expectations.
It also corrects the direction for users to give feedback via the feedback button, rather than the FAQ page