### PR TITLE
Use a fake value for mask return period

### DIFF
--- a/thinkhazard_processing.yaml
+++ b/thinkhazard_processing.yaml
@@ -9,7 +9,7 @@ hazard_types:
       HIG: [10, 25]
       MED: 50
       LOW: [100, 1000]
-    mask_return_period: 5
+    mask_return_period: 9999
     thresholds:
       global:
         cm: 100


### PR DESCRIPTION
We're using 9999 as fake value instead of 5 because hazard set can have a 5 years return period though it shouldn't be taken into account.