### PR TITLE
alembic fix

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -32,10 +32,10 @@ script_location = alembic
 local_settings_path = %(here)s/local.ini
 
 [app:admin]
-sqlalchemy.url = postgresql://www-data:www-data@localhost:5432/foo
+sqlalchemy.url = postgresql://www-data:www-data@localhost:5432/thinkhazard_admin
 
 [app:public]
-sqlalchemy.url = postgresql://www-data:www-data@localhost:5432/bar
+sqlalchemy.url = postgresql://www-data:www-data@localhost:5432/thinkhazard
 
 [alembic:exclude]
 tables = spatial_ref_sys

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -60,10 +60,8 @@ def run_migrations_online():
                     twophase_argument != 'false'
     logger.info("Using two-phase commit: %s" % use_two_phase)
 
-    autogenerating = context.config.cmd_opts and \
-                     'autogenerate' in context.config.cmd_opts and \
-                     context.config.cmd_opts.autogenerate
-    if autogenerating:
+    opts = config.cmd_opts
+    if opts and 'autogenerate' in opts and opts.autogenerate:
         # when generating migration scripts only check the 'admin' db
         names = ['admin']
     else:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -73,8 +73,8 @@ def run_migrations_online():
     # engines, then run all migrations, then commit all transactions.
     engines = {}
     for name in names:
-        settings = context.config.get_section('app:{}'.format(name))
-        settings.update(config.get_section(config.config_ini_section))
+        settings = config.get_section(config.config_ini_section)
+        settings.update(config.get_section('app:{}'.format(name)))
         load_local_settings(settings, name)
         engine = engine_from_config(
             settings,


### PR DESCRIPTION
With this pull request I address the following issue.

When instances are not specific, integrator usually don't set the database url in `local.ini` since the default values are already correct and don't need to be overwritten.
In this case, the `alembic.ini` was taken into account. This raised two problems:
 - race condition of config reading made so the admin database was taken into account for both admin and public applications,
 - the urls in `alembic.ini` were not correctly set.