### PR TITLE
Get git version (new strategy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sqlite
 *.log
 local*.ini
+version.ini
 .build
 node_modules
 thinkhazard/static/build

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ install: \
 		.build/requirements.timestamp \
 		.build/node_modules.timestamp \
 		.build/wkhtmltox \
-		buildcss
+		buildcss \
+		version.ini
 
 .PHONY: buildcss
 buildcss: thinkhazard/static/build/index.css \
@@ -274,3 +275,6 @@ clean:
 cleanall:
 	rm -rf .build
 	rm -rf node_modules
+
+version.ini:
+	git describe --always > $@

--- a/development.ini
+++ b/development.ini
@@ -30,11 +30,11 @@ jinja2.filters =
     route_url = pyramid_jinja2.filters:route_url_filter
     static_url = pyramid_jinja2.filters:static_url_filter
     markdown = thinkhazard.filters:markdown_filter
-    subprocess_check_output = thinkhazard.filters:subprocess_check_output
 jinja2.trim_blocks = true
 jinja2.autoescape = false
 
 local_settings_path = %(here)s/local.ini
+version_path = %(here)s/version.ini
 
 node_modules = %(here)s/node_modules
 

--- a/production.ini
+++ b/production.ini
@@ -29,13 +29,13 @@ jinja2.filters =
     route_url = pyramid_jinja2.filters:route_url_filter
     static_url = pyramid_jinja2.filters:static_url_filter
     markdown = thinkhazard.filters:markdown_filter
-    subprocess_check_output = thinkhazard.filters:subprocess_check_output
 jinja2.trim_blocks = true
 jinja2.autoescape = false
 
 node_modules = %(here)s/node_modules
 
 local_settings_path = %(here)s/local.ini
+version_path = %(here)s/version.ini
 
 # Data folder path
 data_path = /tmp

--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -7,6 +7,7 @@ from papyrus.renderers import GeoJSON
 from .settings import (
     load_processing_settings,
     load_local_settings,
+    get_git_version,
     )
 from .models import (
     DBSession,
@@ -33,6 +34,7 @@ def main(global_config, **settings):
 
     load_processing_settings(settings)
     load_local_settings(settings, settings['appname'])
+    get_git_version(settings)
 
     engine = engine_from_config(settings, 'sqlalchemy.')
     DBSession.configure(bind=engine)

--- a/thinkhazard/filters.py
+++ b/thinkhazard/filters.py
@@ -18,12 +18,7 @@
 # ThinkHazard.  If not, see <http://www.gnu.org/licenses/>.
 
 from markdown import markdown
-import subprocess
 
 
 def markdown_filter(text):
     return markdown(text)
-
-
-def subprocess_check_output(args):
-    return subprocess.check_output(args)

--- a/thinkhazard/settings.py
+++ b/thinkhazard/settings.py
@@ -36,3 +36,12 @@ def load_local_settings(settings, name):
         config = ConfigParser.ConfigParser()
         config.read(local_settings_path)
         settings.update(config.items('app:{}'.format(name)))
+
+
+def get_git_version(settings):
+    """ Get version number from version.ini.
+    """
+    version_path = settings.get('version_path')
+    if version_path and os.path.exists(version_path):
+        with open(version_path, 'r') as f:
+            settings.update({'version': f.read()})

--- a/thinkhazard/templates/about_body.jinja2
+++ b/thinkhazard/templates/about_body.jinja2
@@ -12,7 +12,7 @@
 </p>
 <p>
 The tool code is open source, to encourage other users to adapt the tool to their needs. The code can be found at <a href="https://github.com/GFDRR/thinkhazard" target="_blank">https://github.com/GFDRR/thinkhazard</a>.
-Current instance version is {{ ['git', 'describe', '--always']|subprocess_check_output}}.
+Current instance version is {{request.registry.settings['version']}}.
 </p>
 <div class="row">
   <div class="col-md-12 text-center">


### PR DESCRIPTION
Instead of executing "git describe" each time the page is displayed (which doesn't work correctly in apache mod_wsgi), we put the revision number in an ".ini" and load it via the settings.