### PR TITLE
Change order of apache config directives

### DIFF
--- a/apache.conf
+++ b/apache.conf
@@ -1,17 +1,22 @@
 WSGIPassAuthorization On
 
+##############
+# Public App #
+##############
+<Location {{INSTANCEPATH}}>
+    WSGIProcessGroup thinkhazard:{{INSTANCEID}}
+    WSGIApplicationGroup %{GLOBAL}
+</Location>
+WSGIDaemonProcess thinkhazard:{{INSTANCEID}} \
+    display-name=(wsgi:{{INSTANCEID}}) \
+    user=www-data \
+    group=staff \
+    python-path={{PYTHONPATH}} \
+    processes=4
 
 #############
 # Admin App #
 #############
-
-WSGIDaemonProcess thinkhazard:{{INSTANCEID}}_admin \
-    display-name=(wsgi:{{INSTANCEID}}_admin) \
-    user=www-data group=staff \
-    python-path={{PYTHONPATH}} processes=4
-
-WSGIScriptAlias {{INSTANCEADMINPATH}} {{WSGISCRIPT_ADMIN}}
-
 <Location {{INSTANCEADMINPATH}}>
     WSGIProcessGroup thinkhazard:{{INSTANCEID}}_admin
     WSGIApplicationGroup %{GLOBAL}
@@ -23,20 +28,15 @@ WSGIScriptAlias {{INSTANCEADMINPATH}} {{WSGISCRIPT_ADMIN}}
     AuthName "Authentication Required"
     AuthUserFile {{AUTHUSERFILE}}
 </Location>
+WSGIDaemonProcess thinkhazard:{{INSTANCEID}}_admin \
+    display-name=(wsgi:{{INSTANCEID}}_admin) \
+    user=www-data \
+    group=staff \
+    python-path={{PYTHONPATH}} \
+    processes=4
 
+# Admin App
+WSGIScriptAlias {{INSTANCEADMINPATH}} {{WSGISCRIPT_ADMIN}}
 
-##############
-# Public App #
-##############
-
-WSGIDaemonProcess thinkhazard:{{INSTANCEID}} \
-    display-name=(wsgi:{{INSTANCEID}}) \
-    user=www-data group=staff \
-    python-path={{PYTHONPATH}} processes=4
-
+# Public App
 WSGIScriptAlias {{INSTANCEPATH}} {{WSGISCRIPT}}
-
-<Location {{INSTANCEPATH}}>
-    WSGIProcessGroup thinkhazard:{{INSTANCEID}}
-    WSGIApplicationGroup %{GLOBAL}
-</Location>


### PR DESCRIPTION
Fixes process groups overlap issue.

With the previous apache configuration we were having issues with the public database being used by the admin application. Thus the administrative UI were displaying information not relative to the correct database.

Procedure to reproduce:
 - restart apache,
 - load public interface in browser,
 - load admin interface in browser,
 - reload admin interface several times and compare results.

We discovered that it was due to the fact that the WSGI application were actually sharing the same processes (same pid). The error was apparently showing up randomly but in fact the number of processed (4) was taken into account.
The [mod_wsgi debugging techniques](http://modwsgi.readthedocs.org/en/develop/user-guides/debugging-techniques.html) helped me a lot and I managed to find a solution by reordering apache configuration directives. Precedence is important.

Here's what worked:
 - <Location>'s need to be order so that the less specific appears first (ie. `/` before `/foo`). This makes WSGIProcessGroup correctly set for each application.
 - WSGIScriptAlias' need to be order so that the more specific appears first (ie. `/foo` before `/`). This makes `/admin` correctly taken into account instead of being interpreted as a route for the public application.