### PR TITLE
Do not use mask layer for hazardset quality calculation

### DIFF
--- a/thinkhazard/processing/completing.py
+++ b/thinkhazard/processing/completing.py
@@ -131,6 +131,7 @@ class Completer(BaseProcessor):
             func.min(Layer.calculation_method_quality),
             func.min(Layer.scientific_quality)) \
             .filter(Layer.hazardset_id == hazardset.id) \
+            .filter(Layer.mask.isnot(True)) \
             .group_by(Layer.local)
 
         if stats.count() > 1:


### PR DESCRIPTION
Fix #618.

To update an existing database, execute : 
```
UPDATE processing.hazardset SET complete = FALSE
```
and ``make complete``.

This will update quality fields in hazardset table.