### PR TITLE
Fix errors when restarting postgreSQL

### DIFF
--- a/thinkhazard/scripts/publish.py
+++ b/thinkhazard/scripts/publish.py
@@ -92,7 +92,7 @@ def main(argv=sys.argv):
     call(cmd, shell=True)
 
     print 'Restart PostgreSQL'
-    call(["sudo", "-u", "postgres", "/etc/init.d/postgresql", 'restart'])
+    call(["sudo", "service", "postgresql", 'restart'])
 
     print 'Drop database', public_database
     call(["sudo", "-u", "postgres", "dropdb", public_database])


### PR DESCRIPTION
Happens on recent Debian boxes:

```
sudo -u postgres /etc/init.d/postgresql restart
Restarting postgresql (via systemctl): postgresql.serviceFailed to get D-Bus connection: No such file or directory
 failed!
```