### PR TITLE
Link to geonode document page instead of download link

### DIFF
--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -315,7 +315,7 @@ def get_info_for_hazard_type(request, hazard, division):
             'text': fr.text,
             'url': urlunsplit((geonode['scheme'],
                                geonode['netloc'],
-                               'documents/{}/download'.format(fr.id),
+                               'documents/{}'.format(fr.id),
                                '', ''))
         })
 


### PR DESCRIPTION
Since the download link may be outside the geonode
Fixes #517