### PR TITLE
Change background layer and show neighbouring divisions

### DIFF
--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -139,6 +139,8 @@ def add_public_routes(config):
                      '{hazardtype:([A-Z]{2})}')
     config.add_route('report_json',
                      '/report/{divisioncode:\d+}/{hazardtype:([A-Z]{2})}.json')
+    config.add_route('report_neighbours_json',
+                     '/report/{divisioncode:\d+}/neighbours.json')
     config.add_route('create_pdf_report',
                      '/report/create/{divisioncode:\d+}')
     config.add_route('get_report_status',

--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -10,7 +10,7 @@
   // Main
   //
   var source = new ol.source.XYZ({
-    url: 'https://{a-c}.tiles.mapbox.com/v4/ingenieroariel.m9a2h374/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoiaW5nZW5pZXJvYXJpZWwiLCJhIjoibXhDZ3pIMCJ9.qTmPYCbnUKtaNFkvKKysAQ'
+    url: 'https://api.mapbox.com/styles/v1/gsdpm/cir6ljf470006bsmehhstmxeh/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZ3NkcG0iLCJhIjoiY2lqbmN5eG9mMDBndHVmbTU5Mmg1djF6MiJ9.QqFCD7tcmccysN8GUClW8w'
   });
   waitForTiles();
 

--- a/thinkhazard/static/less/report.less
+++ b/thinkhazard/static/less/report.less
@@ -233,6 +233,11 @@ body {
     font-size: 14px;
     min-width: 100px;
     .box-shadow(0 0 5px 0 rgba(0, 0, 0, 0.15));
+    border: 1px solid #555;
+
+    &.neighbour {
+      border: 1px solid #337ab7;
+    }
   }
 }
 

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -144,6 +144,8 @@ Think Hazard - {{ division.name}}
       app.mapUrl = '{{ 'report_overview_json'|route_url(divisioncode=division.code)}}';
       {% endif %}
 
+      app.neighboursUrl = '{{ 'report_neighbours_json'|route_url(divisioncode=division.code)}}';
+
       {%- if division %}
       app.divisionCode = {{division.code}};
       {%- else %}


### PR DESCRIPTION
Fixes #678.

With this pull request the World Bank mapbox tileset is used.
Also a new interaction is added to the map. It allows users to navigate to neighbouring divisions. This helps going to display and navigate to disputed areas.