### PR TITLE
include licence statement in v1 about page

### DIFF
--- a/thinkhazard/templates/about_body.jinja2
+++ b/thinkhazard/templates/about_body.jinja2
@@ -135,6 +135,7 @@
     <p>
     The tool code is open source, to encourage other users to adapt the tool to their needs. The code can be found on <a href="https://github.com/GFDRR/thinkhazard" target="_blank">Github</a>.
     Current instance version is {{request.registry.settings['version']}}.
+    ThinkHazard! is available under the GNU General Public Licence, Version 3, 29 June 2007. Text content is licenced under CC-BY-SA. Classified hazard levels are licenced under CC-BY. Original hazard data are licenced under their original terms, which are contained in the associated layer metadata.
     </p>
     <p>
       {{licence()}}


### PR DESCRIPTION
@pgiraud 
Please include this licence statement in v1 about page. I edited the about_body.jinja file (my fork)
ThinkHazard! is available under the GNU General Public Licence, Version 3, 29 June 2007. Text content is licenced under CC-BY-SA. Classified hazard levels are licenced under CC-BY. Original hazard data are licenced under their original terms, which are contained in the associated layer metadata.