### PR TITLE
Make the polygons bigger if they are really small

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jquery": "~2.1.3",
     "jshint": "~2.5.1",
     "less": "~1.7.5",
-    "openlayers": "~3.8.2",
+    "openlayers": "~4.0.1",
     "typeahead.js": "~0.11.1",
     "font-awesome": "~4.5.0",
     "d3": "~3.5.16",

--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -37,9 +37,13 @@
 
   var tooltipEl = $('#map .map-tooltip');
 
+  var hitTolerance = 3;
+
   // change mouse cursor when over division
   map.on('pointermove', function(e) {
-    var feature = map.forEachFeatureAtPixel(e.pixel, filterFn);
+    var feature = map.forEachFeatureAtPixel(e.pixel, filterFn, {
+      hitTolerance: hitTolerance
+    });
     var cursor = '';
 
     tooltipEl.empty().removeClass('neighbour').hide();
@@ -76,7 +80,9 @@
 
   // drill down
   map.on('click', function(e) {
-    var feature = map.forEachFeatureAtPixel(e.pixel, filterFn);
+    var feature = map.forEachFeatureAtPixel(e.pixel, filterFn, {
+      hitTolerance: hitTolerance
+    });
     if (feature) {
       var url = feature.get('url');
       if (app.hazardType) {
@@ -244,7 +250,8 @@
       layers: layers,
       condition: ol.events.condition.pointerMove,
       style: styleFn,
-      filter: isSubDivision
+      filter: isSubDivision,
+      hitTolerance: hitTolerance
     });
     map.addInteraction(interaction);
     return interaction;


### PR DESCRIPTION
Fixes #655.
Interactivity enhanced by making the really small and scattered islands a bit bigger than they actually are.

Demo
http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/small_islands/en/report/154-maldives/CY
http://wb-thinkhazard.dev.sig.cloud.camptocamp.net/small_islands/en/report/189-palau/CY

@stufraser1 Can you please validate this?