### PR TITLE
Update thinkhazard_processing.yaml

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -48,6 +48,7 @@ jinja2.newstyle = true
 node_modules = %(here)s/node_modules
 
 local_settings_path = %(here)s/local.ini
+processing_settings_path = %(here)s/thinkhazard_processing.yaml
 
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.

--- a/production.ini
+++ b/production.ini
@@ -40,6 +40,7 @@ jinja2.newstyle = true
 node_modules = %(here)s/node_modules
 
 local_settings_path = %(here)s/local.ini
+processing_settings_path = %(here)s/thinkhazard_processing.yaml
 
 feedback_form_url = https://docs.google.com/forms/d/1m5j6e_cmpsCQftUE6NnS8UbzNs4VoZgop1D5up71YS8/viewform
 

--- a/tests.ini
+++ b/tests.ini
@@ -6,3 +6,4 @@ pdf_archive_path = %(here)s/.build/reports-tests
 [app:admin]
 use = config:development.ini#admin
 local_settings_path = %(here)s/local.tests.ini
+processing_settings_path = %(here)s/thinkhazard/tests/thinkhazard_processing.yaml

--- a/thinkhazard/processing/processing.py
+++ b/thinkhazard/processing/processing.py
@@ -107,6 +107,8 @@ class Processor(BaseProcessor):
         self.type_settings = self.settings['hazard_types'][
             hazardset.hazardtype.mnemonic]
 
+        hazardset.processing_error = None
+
         with rasterio.drivers():
             try:
                 logger.info("  Opening raster files")

--- a/thinkhazard/settings.py
+++ b/thinkhazard/settings.py
@@ -12,18 +12,16 @@ def load_full_settings(config_uri, name='admin', options={}):
     settings = get_appsettings(config_uri,
                                name=name,
                                options=options)
-    load_processing_settings(settings)
     load_local_settings(settings, name)
+    load_processing_settings(settings)
     return settings
 
 
 def load_processing_settings(settings):
     """Load processing specific settings.
     """
-    root_folder = os.path.join(os.path.dirname(__file__), '..')
-    main_settings_path = os.path.join(root_folder,
-                                      'thinkhazard_processing.yaml')
-    with open(main_settings_path, 'r') as f:
+    processing_settings_path = settings['processing_settings_path']
+    with open(processing_settings_path, 'r') as f:
         settings.update(yaml.load(f.read()))
 
 

--- a/thinkhazard/tests/processing/test_completing.py
+++ b/thinkhazard/tests/processing/test_completing.py
@@ -88,9 +88,11 @@ class TestCompleting(unittest.TestCase):
     def setUp(self):  # NOQA
         populate()
 
-    def test_cli(self):
+    @patch.object(Completer, 'do_execute')
+    def test_cli(self, mock):
         '''Test completer cli'''
         Completer.run(['complete', '--config_uri', 'tests.ini'])
+        mock.assert_called_with(hazardset_id=None)
 
     def test_force(self):
         '''Test completer in force mode'''

--- a/thinkhazard/tests/processing/test_downloading.py
+++ b/thinkhazard/tests/processing/test_downloading.py
@@ -19,6 +19,7 @@
 
 import unittest
 import transaction
+from mock import patch
 
 from .. import settings
 from . import populate_datamart
@@ -35,9 +36,11 @@ class TestDownloading(unittest.TestCase):
     def setUp(self):  # NOQA
         populate()
 
-    def test_cli(self):
+    @patch.object(Downloader, 'do_execute')
+    def test_cli(self, mock):
         '''Test downloader cli'''
         Downloader.run(['complete', '--config_uri', 'tests.ini'])
+        mock.assert_called_with(hazardset_id=None, clear_cache=False)
 
     def test_force(self):
         '''Test downloader in force mode'''

--- a/thinkhazard/tests/processing/test_harvesting.py
+++ b/thinkhazard/tests/processing/test_harvesting.py
@@ -77,10 +77,11 @@ class TestHarvesting(unittest.TestCase):
     def setUp(self):  # NOQA
         populate()
 
-    @patch.object(Harvester, 'fetch', return_value=[])
-    def test_cli(self, fetch_mock):
+    @patch.object(Harvester, 'do_execute')
+    def test_cli(self, mock):
         '''Test harvester cli'''
         Harvester.run(['harvest', '--config_uri', 'tests.ini'])
+        mock.assert_called_with(hazard_type=None)
 
     @patch.object(Harvester, 'fetch', return_value=[])
     def test_force(self, fetch_mock):

--- a/thinkhazard/tests/processing/test_process.py
+++ b/thinkhazard/tests/processing/test_process.py
@@ -81,10 +81,11 @@ class TestProcess(unittest.TestCase):
     def setUp(self):  # NOQA
         populate()
 
-    @patch('rasterio.open', return_value=global_reader())
-    def test_cli(self, open_mock):
+    @patch.object(Processor, 'do_execute')
+    def test_cli(self, mock):
         '''Test processor cli'''
-        Processor.run(['complete', '--config_uri', 'tests.ini'])
+        Processor.run(['process', '--config_uri', 'tests.ini'])
+        mock.assert_called_with(hazardset_id=None)
 
     @patch('rasterio.open', return_value=global_reader())
     def test_force(self, open_mock):

--- a/thinkhazard/tests/thinkhazard_processing.yaml
+++ b/thinkhazard/tests/thinkhazard_processing.yaml
@@ -1,0 +1,49 @@
+geonode:
+  scheme: http
+  netloc: test.thinkhazard.org
+
+hazard_types:
+  FL:
+    hazard_type: river_flood
+    return_periods:
+      HIG: [10, 25]
+      MED: 50
+      LOW: [100, 1000]
+    mask_return_period: [2, 5]
+    thresholds:
+      global:
+        cm: 100
+        dm: 10
+        m: 1
+      local:
+        cm: 50
+        dm: 5
+        m: 0.5
+
+  EQ:
+    hazard_type: earthquake
+    return_periods:
+      HIG: [100, 250]
+      MED: [475, 500]
+      LOW: [1000, 2500]
+    thresholds:
+      HIG:
+        PGA-g-dec: 0.2
+        PGA-gal: 196.133
+        PGA-g-per: 20
+      MED:
+        PGA-g-dec: 0.1
+        PGA-gal: 98.0665
+        PGA-g-per: 10
+      LOW:
+        PGA-g-dec: 0.1
+        PGA-gal: 98.0665
+        PGA-g-per: 10
+
+  VA:
+    hazard_type: volcanic_ash
+    values:
+      HIG: [103]
+      MED: [102]
+      LOW: [101]
+      VLO: [100, 0]

--- a/thinkhazard_processing.yaml
+++ b/thinkhazard_processing.yaml
@@ -3,8 +3,8 @@ geonode:
   netloc: www.geonode-gfdrrlab.org
 
 hazard_types:
-  FL:
-    hazard_type: river_flood
+  FL_void:
+    hazard_type: river_flood_void-retain-for-record
     return_periods:
       HIG: [10, 25]
       MED: 50
@@ -19,7 +19,22 @@ hazard_types:
         cm: 50
         dm: 5
         m: 0.5
-
+  
+  FL:
+    hazard_type: river_flood
+    values:
+      HIG: [4]
+      MED: [3]
+      LOW: [2]
+      VLO: [1]
+  UF:
+    hazard_type: urban_flood
+    values:
+      HIG: [4]
+      MED: [3]
+      LOW: [2]
+      VLO: [1]
+  
   EQ:
     hazard_type: earthquake
     return_periods:
@@ -107,7 +122,21 @@ hazard_types:
       MED: [3]
       LOW: [2]
       VLO: [1]
-
+  
+  WF:
+    hazard_type: wildfire
+    return_periods:
+      HIG: 3
+      MED: 10
+      LOW: 30
+    thresholds:
+      HIG:
+        FWI: 15.0
+      MED:
+        FWI: 30.0
+      LOW:
+        FWI: 30.0
+        
   EH:
     hazard_type: extreme_heat
     return_periods:


### PR DESCRIPTION
Added new WF (wildfire) RP and intensity thresholds for processing set of intensity rasters.
Added new UF (urban_flood) values (preprocessed layer, values 1-4)
Added new RF (river_flood) values (preprocessed layer, values 1-4), changed existing RF codes to be void (but would like to retain these for possible future use). Please check whether this changing of the code invalidates it sufficiently, or whether it needs to be removed.