### PR TITLE
Delete layer from cache if data_lastupdated_date has changed

### DIFF
--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -552,6 +552,9 @@ class Harvester(BaseProcessor):
                 layer.downloaded = False
                 hazardset.complete = False
                 hazardset.processed = None
+                # Remove file from cache
+                layer.download_url = download_url
+                os.unlink(self.layer_path(layer))
 
             # Some hazardset fields are calculated during completing
             if (layer.calculation_method_quality !=


### PR DESCRIPTION
Because new file may have the same name as old one.
