### PR TITLE
Deletes non-harvested layers and hazardsets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN pip install -r /app/requirements.txt && pyppeteer-install
 RUN mkdir /tmp/hazardsets && chown www-data /tmp/hazardsets
 VOLUME /tmp/hazardsets
 
+# Geonode API cache
+RUN mkdir /tmp/geonode_api && chown www-data /tmp/geonode_api
+VOLUME /tmp/geonode_api
+
 ENV INI_FILE=c2c://production.ini \
     GEONODE_API_KEY=tbd
 

--- a/docker/testdb/Dockerfile
+++ b/docker/testdb/Dockerfile
@@ -1,3 +1,3 @@
-FROM camptocamp/postgres:9.6
+FROM camptocamp/postgres:12
 
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/tests/processing/__init__.py
+++ b/tests/processing/__init__.py
@@ -46,6 +46,7 @@ class BaseTestCase(unittest.TestCase):
 
     def tearDown(self):  # NOQA
         self.t.rollback()
+        DBSession.expunge_all()
         pass
 
 

--- a/tests/processing/test_harvesting.py
+++ b/tests/processing/test_harvesting.py
@@ -45,6 +45,7 @@ layers_defaults = {
 layer_defaults = layers_defaults
 layer_defaults.update(
     {
+        "regions": [],
         "calculation_method_quality": 5,
         "hazard_period": 10,
         "hazard_unit": "m",
@@ -69,6 +70,10 @@ def layers(values=[{}]):
 def layer(value={}):
     layer = layer_defaults.copy()
     layer.update(value)
+    if not "typename" in value:
+        layer.update({
+            "typename": "{}-{}".format(layer["hazard_set"], layer["hazard_period"])
+        })
     return layer
 
 

--- a/tests/processing/test_harvesting.py
+++ b/tests/processing/test_harvesting.py
@@ -287,6 +287,20 @@ class TestHarvesting(BaseTestCase):
         self.assertEqual(DBSession.query(Layer).count(), 0)
         self.assertEqual(DBSession.query(HazardSet).count(), 0)
 
+    @patch.object(Harvester, "fetch", return_value=layers())
+    @patch.object(
+        httplib2.Http,
+        "request",
+        side_effect=[
+            (Mock(status=200), json.dumps(layer({"id": 1, "hazard_period": 0})))
+        ]
+    )
+    def test_hazardlevel_mismatch(self, request_mock, fetch_mock):
+        """Layers without hazardlevel (invalid hazard_period) should not be harvested"""
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 0)
+        self.assertEqual(DBSession.query(HazardSet).count(), 0)
+
     @patch.object(
         Harvester,
         "fetch",

--- a/tests/processing/test_harvesting.py
+++ b/tests/processing/test_harvesting.py
@@ -272,41 +272,49 @@ class TestHarvesting(BaseTestCase):
             (Mock(status=200), json.dumps(layer()))
         ]
     )
-    def test_layer_harvested_one(self, request_mock, fetch_mock):
-        """Valid layer must be added to database and deleted if not harvested"""
+    def test_hazardset_removed(self, request_mock, fetch_mock):
+        """Empty hazardsets should be removed from database"""
         self.harvester().harvest_layers()
         self.assertEqual(DBSession.query(Layer).count(), 1)
+        self.assertEqual(DBSession.query(HazardSet).count(), 1)
 
         self.harvester().harvest_layers()
         self.assertEqual(DBSession.query(Layer).count(), 0)
+        self.assertEqual(DBSession.query(HazardSet).count(), 0)
 
     @patch.object(
         Harvester,
         "fetch",
         side_effect=[
             layers([{"id": 1}, {"id": 2}]),
-            layers()
+            layers([{"id": 1}])
         ]
     )
     @patch.object(
         httplib2.Http,
         "request",
         side_effect=[
-            (Mock(status=200), json.dumps(layer({"id": 1}))),
-            (Mock(status=200), json.dumps(layer({"id": 2})))
+            (Mock(status=200), json.dumps(layer({"id": 1, "hazard_period": 10}))),
+            (Mock(status=200), json.dumps(layer({"id": 2, "hazard_period": 50}))),
+            (Mock(status=200), json.dumps(layer({"id": 1, "hazard_period": 10}))),
         ]
     )
-    def test_layer_harvested_multi(self, request_mock, fetch_mock):
-        """Valid layers must be added to database and deleted if not harvested"""
+    def test_layer_removed(self, request_mock, fetch_mock):
+        """Layer removed from geonode should be removed from database"""
         self.harvester().harvest_layers()
-        self.assertEqual(DBSession.query(Layer).count(), 1)
-
+        self.assertEqual(DBSession.query(Layer).count(), 2)
         self.assertEqual(DBSession.query(HazardSet).count(), 1)
 
-        self.harvester().harvest_layers()
-        self.assertEqual(DBSession.query(Layer).count(), 0)
+        hazardset = DBSession.query(HazardSet).one()
+        hazardset.completed = True
+        hazardset.processed = datetime.now()
+        DBSession.flush()
 
-        self.assertEqual(DBSession.query(HazardSet).count(), 0)
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 1)
+        self.assertEqual(DBSession.query(HazardSet).count(), 1)
+        self.assertFalse(hazardset.completed)
+        self.assertIsNone(hazardset.processed)
 
     @patch.object(
         httplib2.Http,

--- a/tests/processing/test_harvesting.py
+++ b/tests/processing/test_harvesting.py
@@ -317,6 +317,42 @@ class TestHarvesting(BaseTestCase):
         self.assertIsNone(hazardset.processed)
 
     @patch.object(
+        Harvester,
+        "fetch",
+        side_effect=[
+            layers([{"id": 1}, {"id": 2}]),
+            layers([{"id": 1}, {"id": 2}])
+        ]
+    )
+    @patch.object(
+        httplib2.Http,
+        "request",
+        side_effect=[
+            (Mock(status=200), json.dumps(layer({"id": 1, "hazard_period": 15}))),
+            (Mock(status=200), json.dumps(layer({"id": 2, "hazard_period": 10}))),
+            (Mock(status=200), json.dumps(layer({"id": 1, "hazard_period": 15}))),
+            (Mock(status=200), json.dumps(layer({"id": 2, "hazard_period": 10}))),
+        ]
+    )
+    def test_no_useless_process_invalidate(self, request_mock, fetch_mock):
+        """Multiple layers matching same level should not invalidate processing uselessly"""
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 1)
+        self.assertEqual(DBSession.query(HazardSet).count(), 1)
+
+        hazardset = DBSession.query(HazardSet).one()
+        hazardset.completed = True
+        hazardset.processed = datetime.now()
+        DBSession.flush()
+        DBSession.expunge_all()
+
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 1)
+        self.assertEqual(DBSession.query(HazardSet).count(), 1)
+        self.assertTrue(hazardset.completed)
+        self.assertIsNotNone(hazardset.processed)
+
+    @patch.object(
         httplib2.Http,
         "request",
         side_effect=[

--- a/tests/processing/test_harvesting.py
+++ b/tests/processing/test_harvesting.py
@@ -264,26 +264,49 @@ class TestHarvesting(BaseTestCase):
         hazardset = DBSession.query(HazardSet).one()
         self.assertEqual(hazardset.complete, False)
 
-    @patch.object(Harvester, "fetch", return_value=layers())
+    @patch.object(Harvester, "fetch", side_effect=[layers(), layers([])])
+    @patch.object(
+        httplib2.Http,
+        "request",
+        side_effect=[
+            (Mock(status=200), json.dumps(layer()))
+        ]
+    )
+    def test_layer_harvested_one(self, request_mock, fetch_mock):
+        """Valid layer must be added to database and deleted if not harvested"""
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 1)
+
+        self.harvester().harvest_layers()
+        self.assertEqual(DBSession.query(Layer).count(), 0)
+
+    @patch.object(
+        Harvester,
+        "fetch",
+        side_effect=[
+            layers([{"id": 1}, {"id": 2}]),
+            layers()
+        ]
+    )
     @patch.object(
         httplib2.Http,
         "request",
         side_effect=[
             (Mock(status=200), json.dumps(layer({"id": 1}))),
-            (Mock(status=200), json.dumps(layer({"id": 2}))),
+            (Mock(status=200), json.dumps(layer({"id": 2})))
         ]
     )
-    def test_layer_harvested(self, request_mock, fetch_mock):
-        """Valid layer must be added to database and deleted if not harvested"""
+    def test_layer_harvested_multi(self, request_mock, fetch_mock):
+        """Valid layers must be added to database and deleted if not harvested"""
         self.harvester().harvest_layers()
         self.assertEqual(DBSession.query(Layer).count(), 1)
-        layer_one = DBSession.query(Layer).one()
-        self.assertEqual(layer_one.geonode_id, 1)
+
+        self.assertEqual(DBSession.query(HazardSet).count(), 1)
 
         self.harvester().harvest_layers()
-        self.assertEqual(DBSession.query(Layer).count(), 1)
-        layer_two = DBSession.query(Layer).one()
-        self.assertEqual(layer_two.geonode_id, 2)
+        self.assertEqual(DBSession.query(Layer).count(), 0)
+
+        self.assertEqual(DBSession.query(HazardSet).count(), 0)
 
     @patch.object(
         httplib2.Http,

--- a/tests/views/test_report.py
+++ b/tests/views/test_report.py
@@ -115,7 +115,8 @@ class TestReportFunction(BaseTestCase):
         resp = self.testapp.get("/en/report/31-slug/EQ", status=200)
         self.assertEqual(len(resp.pyquery(".further-resources ul li")), 2)
 
-    def test_report__json(self):
+    @patch("thinkhazard.views.report.GoogleAnalytics.hit")
+    def test_report__json(self, hit_mock):
         self.testapp.get("/en/report/31/EQ.json?resolution=1000", status=200)
 
     def test_report__data_sources(self):

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -590,6 +590,14 @@ class HazardSet(Base):
             .one_or_none()
         )
 
+    def mask_layer(self):
+        return (
+            inspect(self).session.query(Layer)
+            .filter(Layer.hazardset_id == self.id)
+            .filter(Layer.mask.is_(True))
+            .one_or_none()
+        )
+
     def __json__(self, request):
         return {
             "id": self.id,

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -659,6 +659,8 @@ class Layer(Base):
     )
     hazardlevel = relationship("HazardLevel")
 
+    harvested = False
+
     def name(self):
         if self.return_period is None:
             if self.mask:
@@ -669,6 +671,12 @@ class Layer(Base):
 
     def filename(self):
         return self.download_url.split("/").pop()
+
+    def is_harvested(self):
+        return self.harvested
+
+    def set_harvested(self, harvested):
+        self.harvested = harvested
 
 
 class Output(Base):

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -126,8 +126,7 @@ class Harvester(BaseProcessor):
             logger.info(
                 "Settings have been modified, " "passing in force/complete mode."
             )
-            # Commented to test with old DB dump
-            # self.force = True
+            self.force = True
             self.hazard_type = None
 
         try:

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -425,20 +425,20 @@ class Harvester(BaseProcessor):
             if layer.is_harvested() is False:
                 logger.info("Deleting layer {}".format(layer.hazardset_id))
                 self.dbsession.delete(layer)
-
-        hazardsets = self.dbsession.query(HazardSet).all()
-        for hazardset in hazardsets:
-            if len(hazardset.layers) == 0:
-                logger.info("Deleting hazardset {} with output".format(hazardset.id))
-                self.dbsession.query(Output) \
-                    .filter(Output.hazardset_id == hazardset.id) \
-                    .delete()
                 self.dbsession.flush()
-                self.dbsession.delete(hazardset)
-            else:
-                logger.info("Keeping hazardset {}".format(hazardset.id))
-                hazardset.completed = False
-                hazardset.processed = None
+
+                hazardset = layer.hazardset
+                self.dbsession.expire(hazardset)
+                self.dbsession.flush()
+
+                if len(hazardset.layers) == 0:
+                    logger.info("Deleting hazardset {}".format(hazardset.id))
+                    self.dbsession.query(Output).filter(Output.hazardset_id == hazardset.id).delete()
+                    self.dbsession.delete(hazardset)
+                else:
+                    logger.info("Keeping hazardset {}".format(hazardset.id))
+                    hazardset.completed = False
+                    hazardset.processed = None
 
     def harvest_layer(self, object):
         logger.info("Harvesting layer {id} - {title}".format(**object))

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -510,6 +510,9 @@ class Harvester(BaseProcessor):
         if layer is None:
             return
         if layer.hazardlevel != level:
+            looser = hazardset.layer_by_level(level.mnemonic)
+            if looser is not None:
+                looser.hazardlevel = None
             layer.hazardlevel = level
             hazardset.complete = False
             hazardset.processed = None
@@ -520,6 +523,9 @@ class Harvester(BaseProcessor):
         if layer is None:
             return
         if not layer.mask:
+            looser = hazardset.mask_layer()
+            if looser is not None:
+                looser.mask = False
             layer.mask = True
             hazardset.complete = False
             hazardset.processed = None

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -427,15 +427,16 @@ class Harvester(BaseProcessor):
             return [primary_type]
 
     def harvest_layers(self, hazard_type=None):
-        layers_db = self.dbsession.query(Layer).all()
-        for layer in layers_db:
-            layer.set_harvested(False)
         if self.force:
             logger.info("Cleaning previous data")
             self.dbsession.query(Output).delete()
             self.dbsession.query(Layer).delete()
             self.dbsession.query(HazardSet).delete()
             self.dbsession.flush()
+
+        layers_db = self.dbsession.query(Layer).all()
+        for layer in layers_db:
+            layer.set_harvested(False)
 
         # see https://docs.djangoproject.com/en/1.8/ref/models/querysets
         params = {}

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -110,7 +110,8 @@ class Harvester(BaseProcessor):
             logger.info(
                 "Settings have been modified, " "passing in force/complete mode."
             )
-            self.force = True
+            # Commented to test with old DB dump
+            # self.force = True
             self.hazard_type = None
 
         try:
@@ -393,6 +394,9 @@ class Harvester(BaseProcessor):
             return [primary_type]
 
     def harvest_layers(self, hazard_type=None):
+        layers_db_start = self.dbsession.query(Layer).all()
+        for layer in layers_db_start:
+            layer.set_harvested(False)
         if self.force:
             logger.info("Cleaning previous data")
             self.dbsession.query(Output).delete()
@@ -415,6 +419,26 @@ class Harvester(BaseProcessor):
                     )
                 )
                 logger.error(traceback.format_exc())
+
+        layers_db_end = self.dbsession.query(Layer).all()
+        for layer in layers_db_end:
+            if layer.is_harvested() is False:
+                logger.info("Deleting layer {}".format(layer.hazardset_id))
+                self.dbsession.delete(layer)
+
+        hazardsets = self.dbsession.query(HazardSet).all()
+        for hazardset in hazardsets:
+            if len(hazardset.layers) == 0:
+                logger.info("Deleting hazardset {} with output".format(hazardset.id))
+                self.dbsession.query(Output) \
+                    .filter(Output.hazardset_id == hazardset.id) \
+                    .delete()
+                self.dbsession.flush()
+                self.dbsession.delete(hazardset)
+            else:
+                logger.info("Keeping hazardset {}".format(hazardset.id))
+                hazardset.completed = False
+                hazardset.processed = None
 
     def harvest_layer(self, object):
         logger.info("Harvesting layer {id} - {title}".format(**object))
@@ -550,7 +574,8 @@ class Harvester(BaseProcessor):
         if mask:
             layer = layer.filter(Layer.mask.is_(True))
         layer = layer.first()
-        if layer is not None:
+        if layer is not None:   # and layer.is_harvested(): ?
+            print('LAYER HARVESTED ', layer.is_harvested())
             if hazard_period > layer.return_period:
                 logger.info(
                     "  Superseded by shorter return period {}".format(
@@ -638,5 +663,6 @@ class Harvester(BaseProcessor):
         layer.scientific_quality = scientific_quality
         layer.local = local
 
+        layer.set_harvested(True)
         self.dbsession.flush()
         return True

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -394,8 +394,8 @@ class Harvester(BaseProcessor):
             return [primary_type]
 
     def harvest_layers(self, hazard_type=None):
-        layers_db_start = self.dbsession.query(Layer).all()
-        for layer in layers_db_start:
+        layers_db = self.dbsession.query(Layer).all()
+        for layer in layers_db:
             layer.set_harvested(False)
         if self.force:
             logger.info("Cleaning previous data")
@@ -420,8 +420,7 @@ class Harvester(BaseProcessor):
                 )
                 logger.error(traceback.format_exc())
 
-        layers_db_end = self.dbsession.query(Layer).all()
-        for layer in layers_db_end:
+        for layer in layers_db:
             if layer.is_harvested() is False:
                 logger.info("Deleting layer {}".format(layer.hazardset_id))
                 self.dbsession.delete(layer)

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -555,6 +555,7 @@ class Harvester(BaseProcessor):
 
         mask = False
         if preprocessed is True:
+            hazardlevel = None
             hazard_unit = None
             if o['hazard_period']:
                 logger.info('  return period found in preprocessed hazardset')
@@ -563,11 +564,20 @@ class Harvester(BaseProcessor):
 
         else:
             hazard_period = int(o['hazard_period'])
+            hazardlevel = None
+            for level in ("LOW", "MED", "HIG"):
+                if between(hazard_period, type_settings["return_periods"][level]):
+                    hazardlevel = HazardLevel.get(self.dbsession, level)
+                    break
 
             if "mask_return_period" in type_settings and between(
                 hazard_period, type_settings["mask_return_period"]
             ):
                 mask = True
+
+            if hazardlevel is None and not mask:
+                logger.info("  No corresponding hazard_level")
+                return False
 
             hazard_unit = o['hazard_unit']
             if hazard_unit == '':

--- a/thinkhazard/processing/harvesting.py
+++ b/thinkhazard/processing/harvesting.py
@@ -610,7 +610,13 @@ class Harvester(BaseProcessor):
             hazard_period = None
 
         else:
-            hazard_period = int(o['hazard_period'])
+            try:
+                hazard_period = int(o['hazard_period'])
+            except:
+                hazard_period = None
+            if hazard_period is None:
+                logger.info('  no return period found')
+                return False
             hazardlevel = None
             for level in ("LOW", "MED", "HIG"):
                 if between(hazard_period, type_settings["return_periods"][level]):


### PR DESCRIPTION
PR deletes layers, hazardsets and corresponding output in DB that were not harvested from geonode (without using force), to prevent conflicts between thinkhazard application and geonode data

Notes:
* does not handle changing hazardset ids (eg. SSBN => FATHOM) => should not happen, but can be resolved using `harvest --force`