### PR TITLE
[GSWBTH-20] Displays None if no layer has return period

### DIFF
--- a/thinkhazard/templates/report_hazard_category.jinja2
+++ b/thinkhazard/templates/report_hazard_category.jinja2
@@ -164,6 +164,7 @@
             <a href="#" class="rp-chooser {{ 'current-rp' if (layer.return_period == hazardset.layer_by_level(hazard_category.hazardlevel.mnemonic).return_period) }}" data-name="{{layer.typename}}">
               {{layer.return_period if not layer.mask}}</a>
             {% else %}
+            {{ layer.return_period if loop.index == 1 }}
             <input type=hidden class="current-rp" data-name="{{layer.typename}}"/>
             {% endif %}
             {% endfor %}


### PR DESCRIPTION
Displays None under data source map if no layer of hazardset has return period to prevent shift of data owner and intensity unit info into wrong lines.