### PR TITLE
[GSWBTH-15] Displays source and legend also if no layer for requested hazardlevel available

### DIFF
--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -447,6 +447,10 @@
     e.preventDefault();
     var index = ($(this).parent().prop("tagName")==='LI') ? $(this).parent().index() : 0;
     var attr = $($('.current-rp').get(index)).attr('data-name');
+    // takes first layer if no layer was found for requested hazard level
+    if (!attr) {
+      attr = $($('.rp-chooser').get(0)).attr('data-name');
+    }
     dataSourceSource = new ol.source.ImageWMS({
       url: 'http://www.geonode-gfdrrlab.org/geoserver/hazard/ows',
       params: {'LAYERS': attr},


### PR DESCRIPTION
PR requests source and legend of first available layer if no layer for requested hazardlevel is available which usually happens for hazardlevel VLO / hazardlevel_id 4