### PR TITLE
[GSWBTH-46] Returns neighbours geojson also if geom null

### DIFF
--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -234,7 +234,7 @@ def report_geojson(request):
     return [
         {
             "type": "Feature",
-            "geometry": to_shape(geom_simplified),
+            "geometry": to_shape(geom_simplified) if geom_simplified is not None else None,
             "properties": {
                 "name": division.name,
                 "code": division.code,
@@ -490,7 +490,7 @@ def report_neighbours_geojson(request):
     return [
         {
             "type": "Feature",
-            "geometry": to_shape(geom_simplified),
+            "geometry": to_shape(geom_simplified) if geom_simplified is not None else None,
             "properties": {
                 "name": div.name,
                 "code": div.code,


### PR DESCRIPTION
PR prevents neighbours.geojson request from failing if a geometry is null and returns null geometry in response instead (Monaco in case of France's neighbor)

Note: Adapted report_geojson(request) the same way for consistency