### PR TITLE
Always download in force mode

### DIFF
--- a/thinkhazard/processing/downloading.py
+++ b/thinkhazard/processing/downloading.py
@@ -60,6 +60,9 @@ class Downloader(BaseProcessor):
                 os.unlink(file_path)
 
     def do_execute(self, hazardset_id=None, clear_cache=False):
+        # Layer.downloaded field is not reliable in docker context
+        self.force = True
+
         if self.force or clear_cache:
             try:
                 with self.dbsession.begin_nested():


### PR DESCRIPTION
In Openshift container, download status in database is not reliable.