### PR TITLE
Use docker cache on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,10 @@ jobs:
       TX_PWD: ${{ secrets.TX_PWD }}
     steps:
       - uses: actions/checkout@v1
+      - name: Pull
+        run: |
+          docker pull camptocamp/thinkhazard-build:latest || true
+          docker pull camptocamp/thinkhazard:latest || true
       - name: Build
         run: make build
       - name: Lint

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ DOCKER_MAKE_CMD=$(DOCKER_CMD) make -f docker.mk
 
 .PHONY: build
 build: ## Build docker images
-build: docker_build_testdb docker_build_builder docker_build_thinkhazard
+build: docker_build_testdb docker_build_build docker_build_thinkhazard
 
 .PHONY: check
 check: ## Check the code with flake8, jshint and bootlint
@@ -121,16 +121,19 @@ cleanall: clean
 .PHONY: docker_build_thinkhazard
 docker_build_thinkhazard:
 	docker build \
+		--cache-from camptocamp/thinkhazard-build:latest \
+		--cache-from camptocamp/thinkhazard:latest \
 		--build-arg TX_USR=${TX_USR} \
 		--build-arg TX_PWD=${TX_PWD} \
 		--target app -t camptocamp/thinkhazard .
 
-.PHONY: docker_build_builder
-docker_build_builder:
+.PHONY: docker_build_build
+docker_build_build:
 	docker build \
+		--cache-from camptocamp/thinkhazard-build:latest \
 		--build-arg TX_USR=${TX_USR} \
 		--build-arg TX_PWD=${TX_PWD} \
-		--target builder -t camptocamp/thinkhazard-builder .
+		--target builder -t camptocamp/thinkhazard-build .
 
 .PHONY: docker_build_testdb
 docker_build_testdb:

--- a/docker-compose-test.yaml
+++ b/docker-compose-test.yaml
@@ -8,7 +8,7 @@ services:
     image: camptocamp/thinkhazard-testdb
 
   test:
-    image: camptocamp/thinkhazard-builder
+    image: camptocamp/thinkhazard-build
     depends_on:
       - db
       - redis

--- a/docker-compose.override.sample.yaml
+++ b/docker-compose.override.sample.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   thinkhazard:
-    image: camptocamp/thinkhazard-builder
+    image: camptocamp/thinkhazard-build
     environment:
       USE_CACHE: 'TRUE'
     volumes:
@@ -11,10 +11,9 @@ services:
     command: 'pserve --reload c2c://development.ini'
 
   taskrunner:
-    image: camptocamp/thinkhazard-builder
+    image: camptocamp/thinkhazard-build
     environment:
       USE_CACHE: 'TRUE'
     volumes:
       - '${PWD}/development.ini:/app/development.ini'
       - '${PWD}/thinkhazard:/app/thinkhazard'
-    command: 'celery worker -A pyramid_celery.celery_app --ini c2c://development.ini'

--- a/scripts/docker-push
+++ b/scripts/docker-push
@@ -15,7 +15,9 @@ else
 fi
 
 docker_push () {
+    docker tag camptocamp/thinkhazard-build:latest camptocamp/thinkhazard-build:${DOCKER_TAG}
     docker tag camptocamp/thinkhazard:latest camptocamp/thinkhazard:${DOCKER_TAG}
+    docker push camptocamp/thinkhazard-build:${DOCKER_TAG}
     docker push camptocamp/thinkhazard:${DOCKER_TAG}
 }
 


### PR DESCRIPTION
TODO: create the `camptocamp/thinkhazard-build repository` on docker hub