### PR TITLE
Speedup PDF rendering

### DIFF
--- a/alembic/versions/33fe28fefaff_add_simplified_geom.py
+++ b/alembic/versions/33fe28fefaff_add_simplified_geom.py
@@ -1,0 +1,36 @@
+"""Add simplified_geom
+
+Revision ID: 33fe28fefaff
+Revises: 19c37eae5bb2
+Create Date: 2020-05-14 12:35:28.987096
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '33fe28fefaff'
+down_revision = '19c37eae5bb2'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2
+
+
+def upgrade(engine_name):
+    op.add_column('administrativedivision', sa.Column('geom_simplified', geoalchemy2.types.Geometry(geometry_type='MULTIPOLYGON', srid=3857), nullable=True), schema='datamart')
+    conn = op.get_bind()
+    conn.execute('''
+UPDATE datamart.administrativedivision
+SET geom_simplified = ST_Simplify(
+    ST_Transform(geom, 3857),
+    ST_DistanceSphere(
+        ST_Point(ST_XMin(geom), ST_YMin(geom)),
+        ST_Point(ST_XMax(geom), ST_YMax(geom))
+    ) / 250
+);
+''')
+
+
+def downgrade(engine_name):
+    op.drop_column('administrativedivision', 'simplified_geom', schema='datamart')

--- a/alembic/versions/33fe28fefaff_add_simplified_geom.py
+++ b/alembic/versions/33fe28fefaff_add_simplified_geom.py
@@ -15,22 +15,18 @@ depends_on = None
 from alembic import op
 import sqlalchemy as sa
 import geoalchemy2
+from pkg_resources import resource_string
 
 
 def upgrade(engine_name):
     op.add_column('administrativedivision', sa.Column('geom_simplified', geoalchemy2.types.Geometry(geometry_type='MULTIPOLYGON', srid=3857), nullable=True), schema='datamart')
+    op.add_column('administrativedivision', sa.Column('geom_simplified_for_parent', geoalchemy2.types.Geometry(geometry_type='MULTIPOLYGON', srid=3857), nullable=True), schema='datamart')
     conn = op.get_bind()
-    conn.execute('''
-UPDATE datamart.administrativedivision
-SET geom_simplified = ST_Simplify(
-    ST_Transform(geom, 3857),
-    ST_DistanceSphere(
-        ST_Point(ST_XMin(geom), ST_YMin(geom)),
-        ST_Point(ST_XMax(geom), ST_YMax(geom))
-    ) / 250
-);
-''')
+    conn.execute(sa.text(
+        resource_string("thinkhazard", "scripts/simplify.sql").decode("utf8")
+    ))
 
 
 def downgrade(engine_name):
-    op.drop_column('administrativedivision', 'simplified_geom', schema='datamart')
+    op.drop_column('administrativedivision', 'geom_simplified', schema='datamart')
+    op.drop_column('administrativedivision', 'geom_simplified_for_parent', schema='datamart')

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -296,6 +296,7 @@ class AdministrativeDivision(Base):
         ),
     )
     geom = deferred(Column(Geometry("MULTIPOLYGON", 4326)))
+    geom_simplified = deferred(Column(Geometry("MULTIPOLYGON", 3857)))
 
     leveltype = relationship(AdminLevelType)
     parent = relationship(

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -297,6 +297,7 @@ class AdministrativeDivision(Base):
     )
     geom = deferred(Column(Geometry("MULTIPOLYGON", 4326)))
     geom_simplified = deferred(Column(Geometry("MULTIPOLYGON", 3857)))
+    geom_simplified_for_parent = deferred(Column(Geometry("MULTIPOLYGON", 3857)))
 
     leveltype = relationship(AdminLevelType)
     parent = relationship(

--- a/thinkhazard/processing/import.py
+++ b/thinkhazard/processing/import.py
@@ -193,7 +193,14 @@ WITH new_values (
             NULL,
             fre,
             esp,
-            geom
+            geom,
+            geom_simplified = ST_Simplify(
+                ST_Transform(geom, 3857),
+                ST_DistanceSphere(
+                    ST_Point(ST_XMin(geom), ST_YMin(geom)),
+                    ST_Point(ST_XMax(geom), ST_YMax(geom))
+                ) / 250
+            )
         FROM adm{level}_th
 )
 INSERT INTO datamart.administrativedivision (
@@ -202,7 +209,8 @@ INSERT INTO datamart.administrativedivision (
         name,
         name_fr,
         name_es,
-        geom
+        geom,
+        geom_simplified
     )
     SELECT
         code,
@@ -210,7 +218,8 @@ INSERT INTO datamart.administrativedivision (
         name,
         name_fr,
         name_es,
-        geom
+        geom,
+        geom_simplified
     FROM new_values
 ON CONFLICT (code)
 DO
@@ -218,7 +227,8 @@ DO
         SET name = EXCLUDED.name,
             name_fr = EXCLUDED.name_fr,
             name_es = EXCLUDED.name_es,
-            geom = EXCLUDED.geom
+            geom = EXCLUDED.geom,
+            geom_simplified = EXCLUDED.geom_simplified
 ;
 """.format(level=level, levelplus1=level + 1)
 

--- a/thinkhazard/scripts/simplify.sql
+++ b/thinkhazard/scripts/simplify.sql
@@ -1,0 +1,138 @@
+/*
+Calculate approximative display resolution of passed geometry.
+Note that some geometries cross the ante-meridian,
+so we use minimal geodesic distance between bbox opposite corners.
+*/
+CREATE OR REPLACE FUNCTION datamart.resolution(
+    geom geometry
+) RETURNS double precision AS
+$$
+DECLARE
+    distance double precision;
+BEGIN
+
+    distance = ST_Distance(
+        ST_Point(ST_XMin(geom), ST_YMin(geom))::geography,
+        ST_Point(ST_XMax(geom), ST_YMax(geom))::geography
+    );
+    RETURN distance / 250;
+END;
+$$
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE;
+
+/*
+Return simplify version of passed geometry for displaing at passed resolution.
+Make buffer if needed depending on area and resolution.
+*/
+CREATE OR REPLACE FUNCTION datamart.simplify(
+    admindiv datamart.administrativedivision,
+    resolution double precision,
+    parent datamart.administrativedivision DEFAULT NULL
+) RETURNS geometry AS
+$$
+DECLARE
+    name text;
+    geom geometry;
+    parent_geom geometry;
+    area_ratio integer;
+    area double precision;
+    first_tolerance double precision;
+    first_simplified geometry;
+    simplified geometry;
+BEGIN
+    RAISE DEBUG 'Simplifying % - %, level %, % points for resolution % m',
+        admindiv.code,
+        CASE
+            -- Handle wreid encoding error.
+            WHEN admindiv.name LIKE 'Rumid%ahui' THEN 'Rumidahui'
+            ELSE admindiv.name
+        END,
+        admindiv.leveltype_id,
+        ST_NPoints(admindiv.geom),
+        resolution;
+
+    geom = ST_Transform(admindiv.geom, 3857);
+
+    -- If we are threating parent resolution,
+    -- use the parent area to get the same buffer for all geometries.
+    IF parent IS NULL
+    THEN
+        parent_geom = geom;
+    ELSE
+        parent_geom = ST_Transform(parent.geom, 3857);
+    END IF;
+
+    area_ratio = 1000;  -- Minimum number of pixels
+    RAISE DEBUG '  Area';
+    area = ST_Area(parent_geom);
+
+    RAISE DEBUG '    resolution: % km', resolution / 1000;
+    RAISE DEBUG '    pixel size: % km²', pow(resolution, 2) / 1000000;
+    RAISE DEBUG '    needed: % km²', pow(resolution, 2) * area_ratio / 1000000;
+    RAISE DEBUG '    area: % km²', area / 1000000;
+
+    IF area < pow(resolution, 2) * area_ratio
+    THEN
+        -- Simplify a bit first to prevent buffer to be too expensive.
+        first_tolerance = datamart.resolution(admindiv.geom) / 10;
+        RAISE DEBUG '  First simplification: %', first_tolerance;
+        first_simplified = ST_Simplify(geom, first_tolerance);
+        IF ST_NPoints(first_simplified) IS NULL
+        THEN
+            RAISE DEBUG '  First simplification returned null geometry';
+            first_simplified = geom;
+        ELSE
+            RAISE DEBUG '  First simplification result: % points', ST_NPoints(first_simplified);
+        END IF;
+
+        -- Make the polygons a bit bigger.
+        RAISE DEBUG '  Buffer';
+        geom = ST_Buffer(first_simplified, resolution * 2);
+    END IF;
+
+    RAISE DEBUG '  Final simplification';
+    simplified = ST_Simplify(geom, resolution / 2);
+    IF geom IS NULL
+    THEN
+        simplified = geom;
+    END IF;
+
+    RAISE DEBUG '  Final result: % km² for % points',
+        ST_Area(simplified) / 1000000,
+        ST_NPoints(simplified);
+    RETURN ST_Multi(simplified);
+END;
+$$
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE;
+
+-- Update field geom_simplified
+UPDATE datamart.administrativedivision AS admindiv
+SET geom_simplified = datamart.simplify(
+    admindiv.*,
+    datamart.resolution(admindiv.geom)
+);
+
+-- Update field geom_simplified_for_parent
+UPDATE datamart.administrativedivision AS admindiv
+SET geom_simplified_for_parent = datamart.simplify(
+    admindiv.*,
+    datamart.resolution(parent.geom),
+    parent.*
+)
+FROM datamart.administrativedivision AS parent
+WHERE parent.code = admindiv.parent_code;
+
+-- Remove functions to avoid errors with different users.
+DROP FUNCTION datamart.resolution(
+    geom geometry
+);
+DROP FUNCTION datamart.simplify(
+    admindiv datamart.administrativedivision,
+    resolution double precision,
+    parent datamart.administrativedivision
+);
+

--- a/thinkhazard/views/pdf.py
+++ b/thinkhazard/views/pdf.py
@@ -143,19 +143,20 @@ async def create_and_upload_pdf(file_name: str, pages: List[str], object_name: s
     s3_helper.upload_file(file_name, object_name)
 
 
-@view_config(route_name="create_pdf_report", request_method="POST")
+@view_config(route_name="create_pdf_report")
 def create_pdf_report(request):
     """View to create an asynchronous print job.
     """
     publication_date = request.publication_date
     locale = request.locale_name
     division_code = request.matchdict.get("divisioncode")
+    force = "force" in request.params
 
     filename = "{:%Y-%m-%d}-{:s}-{:s}.pdf".format(publication_date, locale, division_code)
     s3_path = "reports/{}".format(filename)
     local_path = os.path.join(tempfile.gettempdir(), filename)
 
-    if not request.s3_helper.download_file(s3_path, local_path):
+    if force or not request.s3_helper.download_file(s3_path, local_path):
         categories = (
             request.dbsession.query(HazardCategory)
             .options(joinedload(HazardCategory.hazardtype))

--- a/thinkhazard/views/pdf.py
+++ b/thinkhazard/views/pdf.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License along with
 # ThinkHazard.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import datetime
 import logging
 import re
@@ -108,8 +109,6 @@ def pdf_cover(request):
 async def create_and_upload_pdf(file_name: str, pages: List[str], object_name: str, s3_helper: S3Helper):
     """Create a PDF file with the given pages using pyppeteer.
     """
-    chunks = []
-
     # --no-sandbox is required to make Chrome/Chromium run under root.
     browser = await launch(
         handleSIGINT=False,
@@ -117,13 +116,17 @@ async def create_and_upload_pdf(file_name: str, pages: List[str], object_name: s
         handleSIGHUP=False,
         args=["--no-sandbox"],
     )
-    page = await browser.newPage()
-    for url in pages:
+
+    async def render_page(url):
+        page = await browser.newPage()
         logger.info("Getting: {}".format(url))
         await page.goto(url, {"waitUntil": "networkidle0"})
-        chunks.append(
-            BytesIO(await page.pdf({"format": "A4", "printBackground": True}))
-        )
+        return BytesIO(await page.pdf({"format": "A4", "printBackground": True}))
+
+    chunks = await asyncio.gather(*[
+        render_page(url) for url in pages
+    ])
+
     await browser.close()
 
     # merge all pages

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -115,7 +115,13 @@ def report(request):
                 [
                     func.ST_Translate(
                         func.ST_Shift_Longitude(
-                            func.ST_Translate(AdministrativeDivision.geom, 180, 0)
+                            func.ST_Translate(
+                                func.ST_Envelope(
+                                    AdministrativeDivision.geom
+                                ),
+                                180,
+                                0
+                            )
                         ),
                         -180,
                         0,


### PR DESCRIPTION
PDF rendering on United States takes approximatively 15 seconds while it was failing after 2 minutes before.

Simultaneous rendering sometimes prevent Gunicorn from restarting. But this seems to be an development only issue as it appends when Gunicorn auto-reload when ovewriting python files in docker volume.

Simplified geometries seems a little more accurate than before but rendered really faster.
Neighbours rendering on US take 1s now instead of 15s before.

Note: It also fix the artefact on Russia geometry when displaying United States.
=> No, I was working with old divisions, error with Russia seems related to new dataset.