### PR TITLE
Replace Mapbox style by camptocamp one

### DIFF
--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -11,8 +11,7 @@
   // Main
   //
   var sources = [
-    'https://api.mapbox.com/styles/v1/stufraser1/cjftf111617x32spjhncapgm2/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1Ijoic3R1ZnJhc2VyMSIsImEiOiJQdnhvZTlnIn0.SEC9tGQDtw9yPQssVyF-8Q',
-    'https://api.mapbox.com/styles/v1/gsdpm/civtq56ch000z2klqcuvgmzdw/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZ3NkcG0iLCJhIjoiY2lqbmN5eG9mMDBndHVmbTU5Mmg1djF6MiJ9.QqFCD7tcmccysN8GUClW8w'
+    'https://api.mapbox.com/styles/v1/camptocamp/ckyoiaovl9zey15pwxnzg3uqj/tiles/256/{z}/{x}/{y}?access_token=pk.eyJ1IjoiY2FtcHRvY2FtcCIsImEiOiJCcmZzU1RBIn0.rVR2B9tbO_pmdm8Z17FAOA',
   ].map(function(url) {
     return new ol.source.XYZ({ url: url });
   });


### PR DESCRIPTION
It seems that at some time there was two superposed styles (one from "stufraser1" and one from "gsdpm").
The one from "gsdpm" does not work anymore so I do not know how it should looks like.

The new one from "camptocamp" looks very similar to "stufraser1", a little more rivers and city labels appear at the same scale.