### PR TITLE
Update MinIO setup and dev compose

### DIFF
--- a/docker-compose.override.sample.yaml
+++ b/docker-compose.override.sample.yaml
@@ -3,6 +3,8 @@ version: '3'
 services:
   thinkhazard:
     image: camptocamp/thinkhazard-builder
+    build: &build
+      target: builder
     environment:
       USE_CACHE: 'TRUE'
     volumes:
@@ -12,6 +14,7 @@ services:
 
   taskrunner:
     image: camptocamp/thinkhazard-builder
+    build: *build
     environment:
       USE_CACHE: 'TRUE'
     volumes:


### PR DESCRIPTION
### Description

This PR makes the following improvements:

- Switches the MinIO setup command from the old config host add to the newer alias set.
- Updates the dev docker-compose to build the image using the builder target