### PR TITLE
Hide show data source button

### DIFF
--- a/thinkhazard/templates/report_hazard_category.jinja2
+++ b/thinkhazard/templates/report_hazard_category.jinja2
@@ -93,7 +93,7 @@
           {{ gettext('Show hazard Level') }}
         </a>
       </div>
-      <div id="data-source-map-btn" class="dropdown btn-group toggle-map-btn">
+      <div id="data-source-map-btn" class="dropdown btn-group toggle-map-btn hidden">
         {% if sources.__len__() > 1 %}
         <button id="dLabel" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="data-source-map-btn" class="btn btn-default dropdown-toggle btn-xs">
           {{ gettext('Show Data Source') }}


### PR DESCRIPTION
### Description
This PR disables the show data source button

### Screenshot
<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1)" src="https://github.com/user-attachments/assets/a430c99f-c15a-43af-98e6-36c8d6f4e8c7" />


#946
