### PR TITLE
Replace deprecated `ST_Shift_Longitude` call with `ST_ShiftLongitude`

### DIFF
--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -112,11 +112,13 @@ def report(request):
             select(
                 [
                     func.ST_Translate(
-                        func.ST_Shift_Longitude(
+                        func.ST_ShiftLongitude(
                             func.ST_Translate(
-                                func.ST_Transform(AdministrativeDivision.geom_simplified, 4326),
+                                func.ST_Transform(
+                                    AdministrativeDivision.geom_simplified, 4326
+                                ),
                                 180,
-                                0
+                                0,
                             )
                         ),
                         -180,


### PR DESCRIPTION
### Description

This PR Replaces `ST_Shift_Longitude` with the current PostGIS function `ST_ShiftLongitude` when handling geometries crossing the dateline in `thinkhazard/views/report.py`

The old `ST_Shift_Longitude`  name is deprecated/non-existent in recent PostGIS versions. We previously relied on a database-side workaround to keep things working, but that wrapper is no longer needed with this change.

### Screenshots
<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (2)" src="https://github.com/user-attachments/assets/850ceb30-d174-44e1-88f9-704c0c828855" />


#949 