### PR TITLE
Create folder /home/user in thinkhazard Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ VOLUME /tmp/geonode_api
 RUN mkdir /tmp/backups && chmod 777 /tmp/backups
 VOLUME /tmp/backups
 
+RUN mkdir -p /home/user && chmod 777 /home/user
+
 ENV AWS_ENDPOINT_URL= \
     GEONODE_URL=tbd \
     GEONODE_USERNAME=tbd \


### PR DESCRIPTION
This is required to create file `.transifexrc` in `tx-init` but was removed with `puppeteer`.