### PR TITLE
Pass geopackage through S3

### DIFF
--- a/thinkhazard/lib/s3helper.py
+++ b/thinkhazard/lib/s3helper.py
@@ -1,5 +1,4 @@
 import boto3
-import logging
 from botocore.client import Config
 from botocore.exceptions import ClientError
 
@@ -23,22 +22,31 @@ class S3Helper:
         # If S3 object_name was not specified, use file_name
         if object_name is None:
             object_name = file_name
+        self.s3_client.upload_file(file_name, self.bucket, object_name)
 
-        try:
-            self.s3_client.upload_file(file_name, self.bucket, object_name)
-        except ClientError as e:
-            logging.error(e)
-            return False
-        return True
+    def upload_fileobj(self, data, object_name):
+        self.s3_client.upload_fileobj(data, self.bucket, object_name)
 
     def download_file(self, object_name, file_name=None):
         # If S3 file_name was not specified, use object_name
         if file_name is None:
             file_name = object_name
+        self.s3_client.download_file(self.bucket, object_name, file_name)
 
+    def delete_object(self, object_name):
+        self.s3_client.delete_object(Bucket=self.bucket, Key=object_name)
+
+    def get_object_url(self, object_name):
+        """Generate S3 URL for an object."""
+        return f"s3://{self.bucket}/{object_name}"
+
+    def object_exists(self, object_name):
         try:
-            self.s3_client.download_file(self.bucket, object_name, file_name)
+            self.s3_client.head_object(Bucket=self.bucket, Key=object_name)
+            return True
         except ClientError as e:
-            logging.error(e)
-            return False
-        return True
+            error_code = e.response['Error']['Code']
+            if error_code == '404':
+                # File doesn't exist
+                return False
+            raise

--- a/thinkhazard/processing/import_geopackage.py
+++ b/thinkhazard/processing/import_geopackage.py
@@ -25,13 +25,14 @@ import geopandas as gpd
 import sqlalchemy
 from shapely.geometry import MultiPolygon, Polygon
 
-from thinkhazard.processing import BaseProcessor
+from thinkhazard.lib.s3helper import S3Helper
 from thinkhazard.models import (
     AdminLevelType,
     AdministrativeDivision,
     HazardCategory,
     HazardCategoryAdministrativeDivisionAssociation,
 )
+from thinkhazard.processing import BaseProcessor
 
 LOG = logging.getLogger(__name__)
 
@@ -126,10 +127,16 @@ class GeopackageImporter(BaseProcessor):
     def do_execute(self, geopackage_path):
         if geopackage_path is None:
             raise ValueError("Geopackage path is required")
-        self.geopackage_path = geopackage_path
+
+        if geopackage_path.startswith("s3://"):
+            LOG.info(f"S3 URL detected: {geopackage_path}")
+            self.geopackage_path = self.download_from_s3(geopackage_path)
+        else:
+            self.geopackage_path = geopackage_path
 
         self.read_adm2()
         self.read_urban()
+
         self.validate()
         self.dissolve()
 
@@ -142,6 +149,28 @@ class GeopackageImporter(BaseProcessor):
         self.recreate_foreign_keys()
 
         self.finish()
+
+    def download_from_s3(self, s3_url):
+        """Download geopackage from S3 URL and return local path."""
+        LOG.info(f"Downloading geopackage from S3: {s3_url}")
+
+        if not s3_url.startswith("s3://"):
+            raise ValueError(f"Invalid S3 URL format: {s3_url}")
+
+        path_part = s3_url[5:]  # Remove 's3://'
+        bucket, object_name = path_part.split("/", 1)
+
+        s3_helper = S3Helper(self.settings)
+        local_path = "/tmp/hazardsets/admindivs.gpkg"
+
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        if os.path.exists(local_path):
+            os.unlink(local_path)
+
+        s3_helper.download_file(object_name, local_path)
+
+        LOG.info(f"Successfully downloaded geopackage to: {local_path}")
+        return local_path
 
     def read_adm2(self):
         if not os.path.isfile(self.geopackage_path):

--- a/thinkhazard/views/admin.py
+++ b/thinkhazard/views/admin.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import contains_eager, joinedload
 import json
 from datetime import datetime
 
+from thinkhazard.lib.s3helper import S3Helper
 from thinkhazard.models import (
     AdminLevelType,
     AdministrativeDivision,
@@ -82,12 +83,12 @@ def upload_geopackage(request):
     if not hasattr(geopackage_file, 'filename'):
         return HTTPFound(request.route_url("admin_index"))
 
-    file_path = f"/tmp/hazardsets/{geopackage_file.filename}"
+    s3_helper = S3Helper(request.registry.settings)
+    object_name = f"tmp/{geopackage_file.filename}"
+    s3_helper.upload_fileobj(geopackage_file.file, object_name)
+    s3_url = s3_helper.get_object_url(object_name)
 
-    with open(file_path, "wb") as f:
-        f.write(geopackage_file.file.read())
-
-    celery_tasks.admindivs_gpkg.delay(file_path)
+    celery_tasks.admindivs_gpkg.delay(s3_url)
     return HTTPFound(request.route_url("admin_index"))
 
 

--- a/thinkhazard/views/pdf.py
+++ b/thinkhazard/views/pdf.py
@@ -163,7 +163,10 @@ def create_pdf_report(request):
     s3_path = "reports/{:%Y-%m-%d}/{}".format(publication_date, filename)
     local_path = os.path.join(tempfile.gettempdir(), filename)
 
-    if force or not request.s3_helper.download_file(s3_path, local_path):
+    if not force and request.s3_helper.object_exists(s3_path):
+        request.s3_helper.download_file(s3_path, local_path)
+
+    if force or not os.path.isfile(local_path):
         categories = (
             request.dbsession.query(HazardCategory)
             .options(joinedload(HazardCategory.hazardtype))


### PR DESCRIPTION
In Kubernetes we need a way to make the geopackage file available to taskrunner.

Here I upload file to an already available S3 bucket and call task with `geopackage_path=S3://bucket/object` so this can be detected in GeoPackageImporter.

I removed error handling from S3Helper class, better to handle exceptions in caller depending on the context, or leave exception propagate.