### PR TITLE
Add URBAN tag to search results and report breadcrumbs

### DIFF
--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -323,6 +323,7 @@ class AdministrativeDivision(Base):
                 "code": self.code,
                 "admin0": getattr(self, attr) or self.name,
                 "url": request.route_url("report_overview", division=self),
+                "mnemonic": self.leveltype.mnemonic,
             }
         if self.leveltype_id == 2:
             return {
@@ -330,6 +331,7 @@ class AdministrativeDivision(Base):
                 "admin0": getattr(self.parent, attr) or self.parent.name,
                 "admin1": getattr(self, attr) or self.name,
                 "url": request.route_url("report_overview", division=self),
+                "mnemonic": self.leveltype.mnemonic,
             }
         if self.leveltype_id == 3:
             return {
@@ -338,6 +340,7 @@ class AdministrativeDivision(Base):
                 "admin1": getattr(self.parent, attr) or self.parent.name,
                 "admin2": getattr(self, attr) or self.name,
                 "url": request.route_url("report_overview", division=self),
+                "mnemonic": self.leveltype.mnemonic,
             }
         if self.leveltype_id == 4:
             return {
@@ -348,6 +351,7 @@ class AdministrativeDivision(Base):
                 "admin2": getattr(self.parent, attr) or self.parent.name,
                 "admin3": getattr(self, attr) or self.name,
                 "url": request.route_url("report_overview", division=self),
+                "mnemonic": self.leveltype.mnemonic,
             }
 
     def slug(self):

--- a/thinkhazard/static/js/search.js
+++ b/thinkhazard/static/js/search.js
@@ -37,7 +37,12 @@
         var tokens = getSortedTokens(data);
         tokens[0] += '<small><em>';
         tokens[tokens.length - 1] += '</em></small>';
-        return '<div>' + tokens.join(', ') + '</div>';
+        var content = tokens.join(', ');
+        var tag = '';
+        if (data.mnemonic === 'URB') {
+          tag = ' <span class="urban-tag">URBAN</span>';
+        }
+        return '<div>' + content + tag + '</div>';
       }
     }
   });

--- a/thinkhazard/static/less/common.less
+++ b/thinkhazard/static/less/common.less
@@ -422,6 +422,23 @@ ul.horizontal li {
   }
 }
 
+.urban-tag {
+  display: inline-block;
+  background-color: #e8e8e8;
+  border-radius: 3px;
+  color: #333;
+  font-size: 10px;
+  font-style: normal;
+  padding: 2px 8px;
+  margin-left: 10px;
+  vertical-align: baseline;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  line-height: 1;
+  position: relative;
+  top: -1px;
+}
+
 /***************
  * breadcrumbd *
  **************/

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -46,6 +46,9 @@ Think Hazard - {{ division.translated_name(request.locale_name)}}
           {% endfor %}
           <button class="btn btn-default disabled">
             {{ division.translated_name(request.locale_name) }}
+            {% if division.leveltype.mnemonic == 'URB' %}
+            <span class="urban-tag">URBAN</span>
+            {% endif %}
           </button>
         </div>
       </div>


### PR DESCRIPTION
### Description

This PR introduces a visual indicator for "Urban" type administrative divisions in both the search dropdown and the report page breadcrumbs to clearly distinguish them from other regions.

### Screenshots

<img width="2020" height="838" alt="image" src="https://github.com/user-attachments/assets/2563b064-7d74-49c2-b586-3bdc7ca4b023" />

<img width="1865" height="535" alt="image" src="https://github.com/user-attachments/assets/b5005ae9-9718-4c74-99eb-6fa586ddbbf9" />
