### PR TITLE
 Fix PDF generation missing maps

### DIFF
--- a/docker/puppeteer/src/server.js
+++ b/docker/puppeteer/src/server.js
@@ -56,8 +56,18 @@ await cluster.task(async ({ page, data: url }) => {
         throw new Error(`Page load failed for URL ${url} with status: ${statusCode}`)
     }
 
-    // Wait for CSS to be applied
-    await new Promise(resolve => setTimeout(resolve, 200));
+    // Wait for map to finish rendering (window.mapRenderingComplete is set by report.js)
+    // This ensures all map tiles and vector layers are fully rendered
+    try {
+        await page.waitForFunction(
+            () => window.mapRenderingComplete === true,
+            { timeout: 15000 }
+        );
+    } catch (e) {
+        console.log(`Map rendering timeout for ${url}, continuing with PDF generation`);
+    }
+
+
 
     // Emulate print media for @media print CSS
     await page.emulateMediaType('print');

--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -190,7 +190,7 @@
     map.addLayer(layer);
     source.on('addfeature', function() {
       map.on('postcompose', function(event) {
-        if (window.status === 'finished') { return; }
+        if (window.mapRenderingComplete === true) { return; }
         vectorLoaded = true;
         checkFinished();
       });
@@ -374,7 +374,8 @@
 
   function checkFinished() {
     if (vectorLoaded && tilesLoaded) {
-      window.status = 'finished';
+
+      window.mapRenderingComplete = true;
       $('#map').addClass('finished');
     }
   }

--- a/thinkhazard/templates/pdf_about.jinja2
+++ b/thinkhazard/templates/pdf_about.jinja2
@@ -26,6 +26,6 @@
     </div>
   </body>
   <script>
-    window.status = 'finished';
+    window.mapRenderingComplete = true;
   </script>
 </html>

--- a/thinkhazard/templates/pdf_cover.jinja2
+++ b/thinkhazard/templates/pdf_cover.jinja2
@@ -105,6 +105,6 @@ d3.json("{{'thinkhazard:static/js/map.topojson'|static_url}}", function(error, w
     </div>
   </body>
   <script>
-    window.status = 'finished';
+    window.mapRenderingComplete = true;
   </script>
 </html>

--- a/thinkhazard/templates/pdf_report.jinja2
+++ b/thinkhazard/templates/pdf_report.jinja2
@@ -25,7 +25,7 @@
   <div class="col-sm-5 col-sm-offset-1">
     <div class="map-block">
       {% if request.params.get('static') == 'true' %}
-        <img onload="window.status='finished'" src="{{'get_map_report'|route_url(_query={'url': request.route_url('report_print', divisioncode=division.code, hazardtype=hazard_category.hazardtype.mnemonic)})}}">
+        <img onload="window.mapRenderingComplete=true" src="{{'get_map_report'|route_url(_query={'url': request.route_url('report_print', divisioncode=division.code, hazardtype=hazard_category.hazardtype.mnemonic)})}}">
       {% else %}
       <div id="map" class="map" data-hazardtype="{{hazard_category.hazardtype.mnemonic if hazard_category else ''}}">
       </div>
@@ -161,7 +161,7 @@
       var app = {};
       app.mapUrl = '{{ 'report_geojson'|route_url(divisioncode=division.code, hazardtype=hazard_category.hazardtype.mnemonic)}}';
       app.neighboursUrl = '{{ 'report_neighbours_geojson'|route_url(divisioncode=division.code)}}';
-      app.divisionCode = {{division.code}};
+      app.divisionCode = '{{division.code}}';
       app.divisionBounds = {{bounds}};
       {% if hazard_category %}
         app.hazardType = '{{hazard_category.hazardtype.mnemonic}}';


### PR DESCRIPTION
### Description

Fixes PDF generation issues where maps were not rendering in the PDF.

*   **Fix ReferenceError**: Added quotes to `division.code` in `pdf_report.jinja2`
*   **Fix Map Timing**: Implemented `window.mapRenderingComplete` to reliably signal when maps are fully rendered (replacing legacy `window.status`).
*   **Cleanup**: Removed redundant waits in `server.js` and all `window.status` usages.