### PR TITLE
Add Disputed Areas (NDLSA) Overlay

### DIFF
--- a/alembic/versions/b2c3d4e5f6a7_add_disputedarea_table.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_disputedarea_table.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""Add disputedarea table for NDLSA (Non-determined legal status areas)
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-01-14 10:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "345f4b2e2934"
+branch_labels = None
+depends_on = None
+
+import geoalchemy2
+import sqlalchemy as sa
+from alembic import op
+
+
+def upgrade(engine_name):
+    op.create_table(
+        "disputedarea",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.Unicode(), nullable=True),
+        sa.Column(
+            "geom",
+            geoalchemy2.types.Geometry(geometry_type="MULTIPOLYGON", srid=4326),
+            nullable=True,
+        ),
+        sa.Column(
+            "geom_simplified",
+            geoalchemy2.types.Geometry(geometry_type="MULTIPOLYGON", srid=3857),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        schema="datamart",
+    )
+
+
+def downgrade(engine_name):
+    op.drop_table("disputedarea", schema="datamart")

--- a/thinkhazard/__init__.py
+++ b/thinkhazard/__init__.py
@@ -178,6 +178,11 @@ def add_public_routes(config):
         "/report/{divisioncode:[A-Z0-9]+}/neighbours.geojson",
     )
     add_localized_route(
+        config,
+        "report_disputed_area_geojson",
+        "/report/disputed_area.geojson",
+    )
+    add_localized_route(
         config, "create_pdf_report", "/report/create/{divisioncode:[A-Z0-9]+}"
     )
 

--- a/thinkhazard/models.py
+++ b/thinkhazard/models.py
@@ -827,3 +827,12 @@ class ContactAdministrativeDivisionHazardTypeAssociation(Base):
     contact = relationship(Contact, backref="associations")
     administrativedivision = relationship(AdministrativeDivision)
     hazardtype = relationship(HazardType)
+
+
+class DisputedArea(Base):
+    __tablename__ = "disputedarea"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(Unicode)
+    geom = deferred(Column(Geometry("MULTIPOLYGON", 4326)))
+    geom_simplified = deferred(Column(Geometry("MULTIPOLYGON", 3857)))

--- a/thinkhazard/processing/import_geopackage.py
+++ b/thinkhazard/processing/import_geopackage.py
@@ -33,6 +33,7 @@ from thinkhazard.models import (
     ContactAdministrativeDivisionHazardTypeAssociation,
     HazardCategory,
     HazardCategoryAdministrativeDivisionAssociation,
+    DisputedArea,
 )
 from thinkhazard.processing import BaseProcessor
 
@@ -98,6 +99,11 @@ CODE_COLUMNS = {
     "URB": "COD_URB",
 }
 
+DISPUTED_AREA_MAPPING = {
+    "NAM_0": "name",
+    "geometry": "geom",
+}
+
 
 def to_multipolygon(geom):
     if geom is None:
@@ -116,7 +122,7 @@ class GeopackageImporter(BaseProcessor):
 
     **Process Overview:**
     1. **Data Source Preparation:** Download from S3 or use local GeoPackage file
-    2. **Data Reading:** Load ADM2 and Urban layers from GeoPackage
+    2. **Data Reading:** Load ADM2, Urban, and disputed area layers from GeoPackage
     3. **Data Validation:** Verify uniqueness, handle null values, remove orphaned territories
     4. **Boundary Dissolution:** Generate ADM1 and ADM0 levels from ADM2 data
     5. **Database Optimization:** Drop foreign key constraints for bulk operations
@@ -149,6 +155,7 @@ class GeopackageImporter(BaseProcessor):
         self.gdf_adm1: gpd.GeoDataFrame | None = None
         self.gdf_adm0: gpd.GeoDataFrame | None = None
         self.gdf_urban: gpd.GeoDataFrame | None = None
+        self.gdf_disputed_area: gpd.GeoDataFrame | None = None
 
     @staticmethod
     def argument_parser():
@@ -175,6 +182,7 @@ class GeopackageImporter(BaseProcessor):
 
         self.read_adm2()
         self.read_urban()
+        self.read_disputed_area()
 
         self.validate()
 
@@ -186,6 +194,7 @@ class GeopackageImporter(BaseProcessor):
         self.recreate_foreign_keys()
 
         self.import_hazard_scores()
+        self.import_disputed_areas()
 
         self.finish()
 
@@ -236,6 +245,22 @@ class GeopackageImporter(BaseProcessor):
         # gdf_urban = gdf_urban.head(100)
 
         self.gdf_urban = gdf_urban
+
+    def read_disputed_area(self):
+        LOG.info("Reading disputed area (NDLSA) source: %s", self.geopackage_path)
+        try:
+            gdf_disputed_area = gpd.read_file(
+                self.geopackage_path, layer="NDLSA", engine="pyogrio"
+            )
+        except Exception as e:
+            LOG.warning("NDLSA layer not found in GeoPackage: %s", e)
+            self.gdf_disputed_area = None
+            return
+
+        LOG.info("Existing columns: %s", list(gdf_disputed_area.columns))
+        LOG.info("Disputed area count: %d", len(gdf_disputed_area))
+
+        self.gdf_disputed_area = gdf_disputed_area
 
     def validate(self):
 
@@ -877,6 +902,33 @@ WHERE NOT EXISTS (
             len(hazard_associations),
             admin_level_mnemonic,
         )
+
+    def import_disputed_areas(self):
+        if self.gdf_disputed_area is None or len(self.gdf_disputed_area) == 0:
+            LOG.info("No disputed area data to import")
+            return
+
+        LOG.info("Importing disputed areas - %d features", len(self.gdf_disputed_area))
+        connection = self.dbsession.connection()
+
+        LOG.info("Truncating disputedarea table")
+        connection.execute(
+            sqlalchemy.text("TRUNCATE TABLE datamart.disputedarea RESTART IDENTITY")
+        )
+
+        gdf = self.gdf_disputed_area[DISPUTED_AREA_MAPPING.keys()]
+        gdf = gdf.rename(columns=DISPUTED_AREA_MAPPING)
+        gdf = gdf.set_geometry("geom")
+        gdf["geom"] = gdf["geom"].apply(to_multipolygon)
+        gdf.to_postgis(
+            schema="datamart",
+            name=DisputedArea.__table__.name,
+            con=connection,
+            if_exists="append",
+            index=False,
+        )
+
+        LOG.info("Successfully imported %d disputed areas", len(gdf))
 
     def finish(self):
         self.dbsession.connection().execute(

--- a/thinkhazard/scripts/simplify.sql
+++ b/thinkhazard/scripts/simplify.sql
@@ -126,6 +126,16 @@ SET geom_simplified_for_parent = datamart.simplify(
 FROM datamart.administrativedivision AS parent
 WHERE parent.code = admindiv.parent_code;
 
+-- Simplify disputed areas geometries
+UPDATE datamart.disputedarea
+SET geom_simplified = ST_Multi(
+        ST_Simplify(
+            ST_Transform(geom, 3857),
+            datamart.resolution(geom) / 2
+        )
+    )
+WHERE geom IS NOT NULL;
+
 -- Remove functions to avoid errors with different users.
 DROP FUNCTION datamart.resolution(
     geom geometry

--- a/thinkhazard/static/js/report.js
+++ b/thinkhazard/static/js/report.js
@@ -43,6 +43,11 @@
   }
   var adminLayer = addAdminLayer(map, app.mapUrl);
 
+  var disputedAreaLayer;
+  if (app.disputedAreaUrl) {
+    disputedAreaLayer = addDisputedAreaLayer(map, app.disputedAreaUrl);
+  }
+
   addSelectInteraction(map, [adminLayer, neighboursLayer]);
 
   var tooltipEl = $('#map .map-tooltip');
@@ -245,12 +250,93 @@
     return layer;
   }
 
+  /**
+   * Create a canvas pattern for hatched fill
+   * @return {CanvasPattern}
+   */
+  function createHatchPattern() {
+    var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
+    var size = 6;
+    canvas.width = size;
+    canvas.height = size;
+
+    context.fillStyle = 'rgba(140, 140, 140, 0.6)';
+    context.fillRect(0, 0, size, size);
+
+    context.strokeStyle = 'rgba(60, 60, 60, 1)';
+    context.lineWidth = 1.5;
+
+    context.beginPath();
+    context.moveTo(size, 0);
+    context.lineTo(0, size);
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(size * 2, 0);
+    context.lineTo(0, size * 2);
+    context.stroke();
+
+    context.beginPath();
+    context.moveTo(0, 0);
+    context.lineTo(-size, size);
+    context.stroke();
+
+    return context.createPattern(canvas, 'repeat');
+  }
+
+
+  /**
+   * Add disputed area overlay layer.
+   * These areas are displayed with a hatched pattern and are non-clickable.
+   * @param {ol.Map} map
+   * @param {string} url
+   * @return {ol.layer.Vector}
+   */
+  function addDisputedAreaLayer(map, url) {
+    var hatchPattern = createHatchPattern();
+
+    var styleFn = function(feature) {
+      var styles = [
+        new ol.style.Style({
+          fill: new ol.style.Fill({
+            color: hatchPattern
+          }),
+          stroke: new ol.style.Stroke({
+            color: 'rgba(50, 50, 50, 1)',
+            width: 1.5
+          })
+        })
+      ];
+      return styles;
+    };
+
+    var source = new ol.source.Vector({
+      url: url,
+      format: new ol.format.GeoJSON({
+        defaultDataProjection: 'EPSG:3857'
+      })
+    });
+
+    var layer = new ol.layer.Vector({
+      style: styleFn,
+      source: source,
+      zIndex: 1000
+    });
+
+    map.addLayer(layer);
+    return layer;
+  }
+
 
   /**
    * @param {ol.Feature} feature
    * @return {?ol.Feature}
    */
   function filterFn(feature) {
+    if (feature.get('disputed')) {
+      return null;
+    }
     if (isSubDivision(feature)) {
       return feature;
     }

--- a/thinkhazard/templates/pdf_report.jinja2
+++ b/thinkhazard/templates/pdf_report.jinja2
@@ -161,6 +161,7 @@
       var app = {};
       app.mapUrl = '{{ 'report_geojson'|route_url(divisioncode=division.code, hazardtype=hazard_category.hazardtype.mnemonic)}}';
       app.neighboursUrl = '{{ 'report_neighbours_geojson'|route_url(divisioncode=division.code)}}';
+      app.disputedAreaUrl = '{{ 'report_disputed_area_geojson'|route_url()}}';
       app.divisionCode = {{division.code}};
       app.divisionBounds = {{bounds}};
       {% if hazard_category %}

--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -151,6 +151,8 @@ Think Hazard - {{ division.translated_name(request.locale_name)}}
 
       app.neighboursUrl = '{{ 'report_neighbours_geojson'|route_url(divisioncode=division.code)}}';
 
+      app.disputedAreaUrl = '{{ 'report_disputed_area_geojson'|route_url()}}';
+
       {%- if division %}
       app.divisionCode = '{{division.code}}';
       {%- else %}

--- a/thinkhazard/views/report.py
+++ b/thinkhazard/views/report.py
@@ -48,6 +48,7 @@ from thinkhazard.models import (
     HazardCategoryAdministrativeDivisionAssociation,
     Contact,
     ContactAdministrativeDivisionHazardTypeAssociation as CAdHt,
+    DisputedArea,
 )
 from ..analytics import GoogleAnalytics
 
@@ -478,4 +479,29 @@ def report_neighbours_geojson(request):
             },
         }
         for div, geom_simplified in divisions
+    ]
+
+
+@view_config(route_name="report_disputed_area_geojson", renderer="geojson")
+def report_disputed_area_geojson(request):
+    """
+    Return GeoJSON for all disputed areas.
+    These are disputed territories that should be displayed as an overlay on the map.
+    """
+    disputed_areas = request.dbsession.query(DisputedArea).add_columns(
+        DisputedArea.geom_simplified
+    )
+
+    return [
+        {
+            "type": "Feature",
+            "geometry": (
+                to_shape(geom_simplified) if geom_simplified is not None else None
+            ),
+            "properties": {
+                "name": area.name,
+                "disputed": True,
+            },
+        }
+        for area, geom_simplified in disputed_areas
     ]


### PR DESCRIPTION
### Description
Adds support for displaying Disputed Areas (Non-Determined Legal Status Areas) as a non-interactive overlay on risk report maps.

#### Changes
- **Database**: 
  - Added `disputedarea` table and model.
  - Added Alembic migration for the new table.
- **Import**: 
  - Updated import logic to process the `NDLSA` layer from GeoPackage sources.
  - Updated geometry simplification logic to support disputed areas.
- **API**: 
  - Added new endpoint to serve disputed areas as GeoJSON.
- **Frontend**: 
  - Added new map layer for disputed areas using a hatched pattern.
  - Configured the layer to be non-clickable and always on top.
- **PDF**: 
  - Updated PDF generation templates to include the disputed area layer.

### Screenshots

<img width="1181" height="609" alt="image" src="https://github.com/user-attachments/assets/bbdd058d-563e-46a8-b883-e6289e364ae7" />

<img width="1181" height="609" alt="image" src="https://github.com/user-attachments/assets/8ed0c6f6-8270-43ee-84d8-0ed575a18466" />

<img width="1181" height="609" alt="image" src="https://github.com/user-attachments/assets/a716b878-4daa-431c-bc83-e4bc1754e3ac" />


#941 