### PR TITLE
Used node:18-alpine instead of installing node in builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,37 @@ ENV AWS_ENDPOINT_URL= \
     LOG_LEVEL_SQLALCHEMY=WARN \
     USE_CACHE=FALSE
 
+
+########################
+# Build frontend files #
+########################
+FROM node:18-alpine AS node
+
+WORKDIR /app/thinkhazard/
+COPY package.json ./
+RUN --mount=type=cache,target=/root/.npm \
+    npm install
+
+COPY thinkhazard/static/ ./thinkhazard/static/
+
+RUN mkdir -p thinkhazard/static/build && \
+    npx lessc --include-path=node_modules --clean-css thinkhazard/static/less/index.less thinkhazard/static/build/index.min.css && \
+    npx lessc --include-path=node_modules thinkhazard/static/less/index.less thinkhazard/static/build/index.css && \
+    npx lessc --include-path=node_modules --clean-css thinkhazard/static/less/report.less thinkhazard/static/build/report.min.css && \
+    npx lessc --include-path=node_modules thinkhazard/static/less/report.less thinkhazard/static/build/report.css && \
+    npx lessc --include-path=node_modules --clean-css thinkhazard/static/less/report_print.less thinkhazard/static/build/report_print.min.css && \
+    npx lessc --include-path=node_modules thinkhazard/static/less/report_print.less thinkhazard/static/build/report_print.css && \
+    npx lessc --include-path=node_modules --clean-css thinkhazard/static/less/common.less thinkhazard/static/build/common.min.css && \
+    npx lessc --include-path=node_modules thinkhazard/static/less/common.less thinkhazard/static/build/common.css && \
+    npx lessc --include-path=node_modules --clean-css thinkhazard/static/less/admin.less thinkhazard/static/build/admin.min.css && \
+    npx lessc --include-path=node_modules thinkhazard/static/less/admin.less thinkhazard/static/build/admin.css
+
+RUN mkdir -p thinkhazard/static/fonts && \
+    cp node_modules/font-awesome/fonts/fontawesome-webfont.* thinkhazard/static/fonts/
+
+RUN npx jshint thinkhazard/static/js/**/*.js
+
+
 ########################
 # Build and test image #
 ########################
@@ -72,21 +103,8 @@ RUN --mount=type=cache,target=/var/lib/apt/lists \
     make \
     curl
 
-RUN \
-  . /etc/os-release && \
-  echo "deb https://deb.nodesource.com/node_18.x ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/nodesource.list && \
-  curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  apt-get update && \
-  apt-get install --assume-yes --no-install-recommends \
-    'nodejs=18.*' \
-    && \
-  echo "Keep apt cache for now"
-  #apt-get clean && \
-  #rm --recursive --force /var/lib/apt/lists/*
-
-COPY package.json /opt/thinkhazard/
-RUN cd /opt/thinkhazard/ && npm install
-ENV PATH=${PATH}:${NODE_PATH}/.bin/
+COPY --from=node /app/thinkhazard/node_modules /opt/thinkhazard/node_modules
+COPY --from=node /app/thinkhazard/thinkhazard/static/build /opt/thinkhazard/thinkhazard/static/build
 
 # Install OpenLayers from release, not source.
 RUN mkdir --parent /opt/thinkhazard/node_modules/openlayers/dist \

--- a/docker.mk
+++ b/docker.mk
@@ -9,38 +9,7 @@ PY_FILES = $(shell find thinkhazard -type f -name '*.py' 2> /dev/null)
 #########################
 
 .PHONY: build
-build: buildcss compile_catalog
-
-.PHONY: buildcss
-buildcss: \
-		/opt/thinkhazard/thinkhazard/static/build/index.css \
-		/opt/thinkhazard/thinkhazard/static/build/index.min.css \
-		/opt/thinkhazard/thinkhazard/static/build/report.css \
-		/opt/thinkhazard/thinkhazard/static/build/report.min.css \
-		/opt/thinkhazard/thinkhazard/static/build/report_print.css \
-		/opt/thinkhazard/thinkhazard/static/build/report_print.min.css \
-		/opt/thinkhazard/thinkhazard/static/build/common.css \
-		/opt/thinkhazard/thinkhazard/static/build/common.min.css \
-		/opt/thinkhazard/thinkhazard/static/build/admin.css \
-		/opt/thinkhazard/thinkhazard/static/build/admin.min.css \
-		$(addprefix /opt/thinkhazard/thinkhazard/static/fonts/fontawesome-webfont., eot ttf woff woff2)
-
-/opt/thinkhazard/thinkhazard/static/build/%.min.css: $(LESS_FILES)
-	mkdir -p $(dir $@)
-	lessc --include-path=${NODE_PATH} --clean-css thinkhazard/static/less/$*.less $@
-
-/opt/thinkhazard/thinkhazard/static/build/%.css: $(LESS_FILES)
-	mkdir -p $(dir $@)
-	lessc --include-path=${NODE_PATH} thinkhazard/static/less/$*.less $@
-
-.PRECIOUS: ${NODE_PATH}/font-awesome/fonts/fontawesome-webfont.%
-${NODE_PATH}/font-awesome/fonts/fontawesome-webfont.%:
-	touch -c $@
-
-/opt/thinkhazard/thinkhazard/static/fonts/fontawesome-webfont.%: ${NODE_PATH}/font-awesome/fonts/fontawesome-webfont.%
-	mkdir -p $(dir $@)
-	cp $< $@
-
+build: compile_catalog
 
 .PHONY: compile_catalog
 compile_catalog: \
@@ -64,13 +33,8 @@ $(HOME)/.transifexrc:
 	@echo "token = $(TX_TOKEN)" >> $@
 	cat $@
 
-
-check: flake8 jshint
+check: flake8
 
 .PHONY: flake8
 flake8:
 	flake8 $(PY_FILES)
-
-.PHONY: jshint
-jshint:
-	jshint --verbose $(JS_FILES)


### PR DESCRIPTION
Fix build:

```
#32 1.265 Err:6 https://deb.nodesource.com/node_18.x bullseye InRelease
#32 1.265   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
#32 1.896 Reading package lists...
#32 2.272 W: GPG error: https://deb.nodesource.com/node_18.x bullseye InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 1655A0AB68576280
#32 2.272 E: The repository 'https://deb.nodesource.com/node_18.x bullseye InRelease' is not signed.
```

Instead of fixing this, IMHO it seems better to directly use a node Docker image.