### PR TITLE
Add data source attribution for urban areas 

### DIFF
--- a/thinkhazard/templates/report_hazard_category.jinja2
+++ b/thinkhazard/templates/report_hazard_category.jinja2
@@ -151,6 +151,13 @@
       {{ hazard_category.hazardtype.data_owner_info | markdown }}
     </div>
     {% endif %}
+    {% if division.leveltype.mnemonic == 'URB' %}
+    <div class="data-owner-info">
+        <p>
+          {{ gettext('Urban areas perimeters are obtained from %(link)s.', link='[GHS Urban Centre Database 2025](https://human-settlement.emergency.copernicus.eu/ghs_ucdb_2024.php)') | markdown }}
+        </p>
+    </div>
+    {% endif %}
     <div id="data-source-legend" class="legend hidden row">
       <div class="col-xs-3">
         {% for hazardset in sources %}


### PR DESCRIPTION
### Description
This PR adds a data source attribution for urban areas in the hazard report page.

### Screenshot
<img width="411" height="692" alt="image" src="https://github.com/user-attachments/assets/988c7738-884f-4c46-837d-a9e9f7438ed1" />

#1009 