### PR TITLE
Add scrolling news ticker banner to homepage

### DIFF
--- a/thinkhazard/static/less/index.less
+++ b/thinkhazard/static/less/index.less
@@ -152,7 +152,7 @@ footer {
 
 .news-ticker {
   width: 100%;
-  background: #2980b9;
+  background: #D91F2C;
   overflow: hidden;
   padding: 8px 0;
 }

--- a/thinkhazard/templates/index.jinja2
+++ b/thinkhazard/templates/index.jinja2
@@ -6,7 +6,7 @@
 {% block name %}index{% endblock %}
 
 {% block content %}
-  {% set ticker_message = "NEWS TICKER - NEW VERSION UPDATE — Content coming soon!" %}
+  {% set ticker_message = "Data update 2026 - New global hazard layers - Refined classification approach - Hazard classification extented to 3,000 urban areas - Please check updated documentation" %}
   <div class="news-ticker">
     <div class="ticker-track">
       <span class="ticker-text">{{ ticker_message }}</span>


### PR DESCRIPTION
### Description
Adds a scrolling news ticker banner at the top of the homepage for displaying version update announcements.


### Status
 **Work in Progress** - Ticker content is placeholder and will be updated when final text is confirmed.

### Screenshot
<img width="1436" height="891" alt="image" src="https://github.com/user-attachments/assets/e3f90241-9ec4-404b-b5ab-45f627fd0ed8" />

#1009 