### PR TITLE
Pyramid still require pkg_resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ requests_futures
 secure<1,>=0.3
 shapely>=2.1.2
 simplejson
+setuptools<82  # As pyramid still require pkg_resources
 transaction
 waitress
 zope.sqlalchemy


### PR DESCRIPTION
But pk_resources has been removed from setuptools in v82?

See: https://github.com/pypa/setuptools/pull/5007