### PR TITLE
Fix missing aggregated hazard scores for ADM0 and ADM1 administrative divisions

### DIFF
--- a/tests/data/ADM2.geojson
+++ b/tests/data/ADM2.geojson
@@ -36,7 +36,11 @@
         "NAM_0_FR": "Testlande",
         "NAM_1_EN": "Sample Province",
         "NAM_1_ES": "Provincia Ejemplo",
-        "NAM_1_FR": "Province Exemple"
+        "NAM_1_FR": "Province Exemple",
+        "CF_Hazard_score": 0,
+        "DG_Hazard_score": 0,
+        "FL_Hazard_score": 0,
+        "PF_Hazard_score": 0
       },
       "geometry": {
         "type": "MultiPolygon",
@@ -81,7 +85,11 @@
         "NAM_0_FR": "Testlande Outre-Mer",
         "NAM_1_EN": "Overseas Province",
         "NAM_1_ES": "Provincia Ultramar",
-        "NAM_1_FR": "Province d'Outre-Mer"
+        "NAM_1_FR": "Province d'Outre-Mer",
+        "CF_Hazard_score": 0,
+        "DG_Hazard_score": 0,
+        "FL_Hazard_score": 0,
+        "PF_Hazard_score": 0
       },
       "geometry": {
         "type": "MultiPolygon",

--- a/tests/data/URB.geojson
+++ b/tests/data/URB.geojson
@@ -41,9 +41,13 @@
         "NAM_URB_EN": "Test City",
         "NAM_URB_ES": "Ciudad Prueba",
         "NAM_URB_FR": "Ville Test",
-        "CAPITAL": false
+        "CAPITAL": false,
+        "CF_Hazard_score": 0,
+        "DG_Hazard_score": 0,
+        "FL_Hazard_score": 0,
+        "PF_Hazard_score": 0
       },
-       "geometry": {
+      "geometry": {
         "type": "MultiPolygon",
         "coordinates": [
           [

--- a/thinkhazard/processing/import_geopackage.py
+++ b/thinkhazard/processing/import_geopackage.py
@@ -379,15 +379,7 @@ class GeopackageImporter(BaseProcessor):
                         self.gdf_urban = self.gdf_urban[~urban_orphan_mask]
 
     def dissolve(self):
-        hazard_score_cols = [
-            "LS_Hazard_score",
-            "EQ_Hazard_score",
-            "TC_Hazard_score",
-            "VO_Hazard_score",
-            "EH_Hazard_score",
-            "TS_Hazard_score",
-            "WF_Hazard_score",
-        ]
+        hazard_score_cols = list(HAZARD_SCORE_COLUMNS.keys())
 
         LOG.info("Extracting ADM1 boundaries...")
         self.gdf_adm1 = self.gdf_adm2.dissolve(


### PR DESCRIPTION
### Description
Fixes an issue where hazard scores for ADM0 and ADM1 levels were entirely missing from the DB and the report page after importing the GeoPackage.

Removed the static `hazard_score_cols` list within the `dissolve()` method and replaced it with a dynamic reference to `list(HAZARD_SCORE_COLUMNS.keys())`. This guarantees that any hazard tracked in the central dictionary will be correctly aggregated and stored for higher-level administrative divisions going forward.

#1018

