### PR TITLE
Update search result tags for Urban Areas and administrative divisions

### DIFF
--- a/thinkhazard/static/js/search.js
+++ b/thinkhazard/static/js/search.js
@@ -91,13 +91,9 @@
     if (data.mnemonic === 'COU') {
       return '<span class="result-tag country">Country</span>';
     }
-    if (data.mnemonic === 'URB' && data.is_capital) {
-      return '<span class="result-tag capital">Capital</span>';
-    }
     if (data.mnemonic === 'URB') {
-      return '<span class="result-tag ghsl">GHSL Urban Center</span>';
+      return '<span class="result-tag ghsl">Urban Area</span>';
     }
-    return '<span class="result-tag admindiv">ADM DIVISION</span>';
   }
 
 })();


### PR DESCRIPTION
### Description
This PR updates the visual UI tags applied to search results to provide a cleaner and more consistent user experience.

**Changes Made:**
* **Urban Areas**: Renamed the GHSL tag from `"GHSL Urban Center"` to `"Urban Area"`.
* **Capital Flags**: Removed the explicit `"Capital"` tag in the frontend UI. *(Note: The underlying ranking algorithm that prioritizes capital cities remains unaffected)*.
* **Administrative Divisions (ADM1, ADM2)**: Removed the generic `"ADM DIVISION"` tag, leaving sub-national regions unlabeled in the search dropdown to reduce visual clutter. 
* **Countries**: The `"Country"` tag for ADM0 (`COU`) searches is retained.

### Screenshots

<img width="947" height="715" alt="image" src="https://github.com/user-attachments/assets/4815071d-742a-4d42-803d-3a497f7e1da6" />


#1018 
