### PR TITLE
Refactor hazard reports to replace detailed recommendations with documentation link

### DIFF
--- a/tests/views/test_report.py
+++ b/tests/views/test_report.py
@@ -94,7 +94,7 @@ class TestReportFunction(BaseTestCase):
     def test_report__hazard(self):
         resp = self.testapp.get("/en/report/32-slug/EQ", status=200)
         self.assertTrue("Climate change recommendation" in resp.text)
-        self.assertEqual(len(resp.pyquery(".recommendations li")), 2)
+        # self.assertEqual(len(resp.pyquery(".recommendations li")), 2)
 
     def test_report__further_resources_division(self):
         # admin div 12 is not linked with any region => no further resource

--- a/thinkhazard/templates/pdf_report.jinja2
+++ b/thinkhazard/templates/pdf_report.jinja2
@@ -71,6 +71,7 @@
     </div>
   </div>
 </div>
+{#
 {% if recommendations %}
 <div class="row">
   <div class="col-sm-12">
@@ -86,6 +87,15 @@
   </div>
 </div>
 {% endif %}
+#}
+
+<div class="row">
+  <div class="col-sm-12">
+    <p>
+      For hazard management recommendations, see <a href="https://gfdrr.github.io/thinkhazard/drr-guidance/">documentation</a>.
+    </p>
+  </div>
+</div>
 <hr>
 {% if resources and resources|length > 0 %}
 <div class="row">

--- a/thinkhazard/templates/report_hazard_category.jinja2
+++ b/thinkhazard/templates/report_hazard_category.jinja2
@@ -28,6 +28,7 @@
     </p>
     {% endif %}
 
+    {#
     {% if hazard_category.tec_rec_associations %}
     <h3>{{gettext('Recommendations')}}</h3>
     <ul class="recommendations">
@@ -62,6 +63,11 @@
     {% endfor %}
     </ul>
     {% endif %}
+    #}
+
+    <p>
+      For hazard management recommendations, see <a href="https://gfdrr.github.io/thinkhazard/drr-guidance/" target="_blank">documentation</a>.
+    </p>
   {% else %}
     <aside class="hazard-level">
       {{gettext('Hazard level')}}


### PR DESCRIPTION
### Description
This PR refactors the hazard report templates (both the web UI and PDF exports) to replace the inline technical recommendations list with a direct link to the ThinkHazard DRR guidance documentation. 

### Screenshots
<img width="1245" height="1079" alt="image" src="https://github.com/user-attachments/assets/8055818b-22ee-4dc6-932b-aed710a0cb4c" />

#1038

