### PR TITLE
Fix PDF report layout: hazard name overlap, disclaimer page break, and data source cleanup

### DIFF
--- a/thinkhazard/static/less/report_print.less
+++ b/thinkhazard/static/less/report_print.less
@@ -32,6 +32,10 @@ a.logo {
   margin-top: 10px;
 }
 
+.disclaimer {
+  page-break-before: always;
+}
+
 
 /* Styles specific to the cover page */
 .cover {
@@ -39,7 +43,7 @@ a.logo {
     margin-top: 40px;
   }
   .footer {
-    margin-top: 100px;
+    margin-top: 80px;
   }
 
   #world_map {
@@ -123,11 +127,15 @@ a.logo {
   padding: 0;
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   li {
-    flex: 1;
+    width: auto;
     min-width: 5em;
+    font-size: 12px;
     text-align: center;
     padding-top: 0;
+    padding-left: 6px;
+    padding-right: 6px;
     margin-top: 1em;
     border: 0;
     .hazard-icon {

--- a/thinkhazard/templates/pdf_report.jinja2
+++ b/thinkhazard/templates/pdf_report.jinja2
@@ -62,6 +62,7 @@
       </table>
     </div>
 
+{#
     <div class="data-source text-center small">
       {{ngettext('Data source:', 'Data sources:', sources.__len__())}}
       {% for source in sources %}
@@ -69,6 +70,7 @@
       {% if not loop.last %},&nbsp;{% endif %}
       {% endfor %}
     </div>
+#}
   </div>
 </div>
 {#


### PR DESCRIPTION
### Description
After updating hazard names (e.g. "Tropical cyclone", "Water scarcity", "Extreme heat"), the PDF cover page had overlapping text labels because `report.less` enforces a fixed width on hazard list items. Additionally, the disclaimer section was splitting across two pages, and the data source section was still visible in the PDF despite being commented out in the web report. 

This PR resolves the layout issues by adjusting the PDF print styles so that hazard items size dynamically to fit their content with appropriate padding, and forces a page break before the disclaimer section. The data source snippet has also been commented out in the PDF report template to match the rest of the application.

### Screenshots

1. **Hazard List**
<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (3)" src="https://github.com/user-attachments/assets/8dbb1f3f-e8dd-4cf5-8d8f-df64e3c17114" />

2. **Disclaimer Split**
<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (4)" src="https://github.com/user-attachments/assets/a6e0f333-059c-4058-b0ec-6a7729c92fa3" />

3. **Data Source**
<img width="4032" height="3024" alt="BeforeAfterLandscape copy (1) (5)" src="https://github.com/user-attachments/assets/d86ad67e-6594-4be0-bced-0ec4d5535bd4" />
