### PR TITLE
Remove social share icons from report page

### DIFF
--- a/thinkhazard/templates/report.jinja2
+++ b/thinkhazard/templates/report.jinja2
@@ -106,7 +106,7 @@ Think Hazard - {{ division.translated_name(request.locale_name)}}
             {{gettext('We welcome any suggestions for improvements to the tool, including suggestions of data, recommendations, or resources to include.')}}
             <br>
             {{gettext('If you have any, please [provide feedback](%(link)s).', link=feedback_form_url)|markdown}}
-            <hr>
+            {#<hr>
             <div class="socialbutton-wrapper">
               {{gettext('Share')}}
               <a class="btn btn-info twitter" href="https://twitter.com/share?url={{request.current_route_url()}}">
@@ -115,7 +115,7 @@ Think Hazard - {{ division.translated_name(request.locale_name)}}
               <a class="btn btn-primary facebook" href="https://www.facebook.com/sharer/sharer.php?u={{request.current_route_url()}}">
                 <img src="{{'thinkhazard:static/images/icon-facebook-new.png'|static_url}}" alt="Facebook">
               </a>
-            </div>
+            </div> #}
 
           </div>
         </div>


### PR DESCRIPTION
### Description
This PR removes the social share (Twitter/X and Facebook) buttons from the bottom of the report page, matching the earlier removal of these icons from the header navigation. 

### Screenshots
<img width="1173" height="247" alt="image" src="https://github.com/user-attachments/assets/245d56db-0cab-45e9-b5f5-9b88822f0117" />
