### PR TITLE
Update PDF reports to use new hazard data source logic

### DIFF
--- a/thinkhazard/templates/pdf_report.jinja2
+++ b/thinkhazard/templates/pdf_report.jinja2
@@ -62,15 +62,17 @@
       </table>
     </div>
 
-{#
+    {% if hazard_category.hazardtype.data_owner_info or division.leveltype.mnemonic == 'URB' %}
     <div class="data-source text-center small">
-      {{ngettext('Data source:', 'Data sources:', sources.__len__())}}
-      {% for source in sources %}
-      {{ source.owner_organization}}
-      {% if not loop.last %},&nbsp;{% endif %}
-      {% endfor %}
+      {{ gettext('Data sources:') }}<br>
+      {% if hazard_category.hazardtype.data_owner_info %}
+      {{ hazard_category.hazardtype.data_owner_info | markdown | replace('<p>', '') | replace('</p>', '') | safe }}<br>
+      {% endif %}
+      {% if division.leveltype.mnemonic == 'URB' %}
+      {{ gettext('Urban areas perimeters are obtained from %(link)s.', link='[GHS Urban Centre Database 2025](https://human-settlement.emergency.copernicus.eu/ghs_ucdb_2024.php)') | markdown | replace('<p>', '') | replace('</p>', '') | safe }}
+      {% endif %}
     </div>
-#}
+    {% endif %}
   </div>
 </div>
 {#
@@ -91,6 +93,7 @@
 {% endif %}
 #}
 
+<br>
 <div class="row">
   <div class="col-sm-12">
     <p>


### PR DESCRIPTION
### Description
This PR updates the PDF report template to use the new hazard-specific data source logic

Previously, the PDF generation was relying on a legacy, commented-out logic loop for data sources that is no longer valid. 

### Screenshots

<img width="1524" height="651" alt="image" src="https://github.com/user-attachments/assets/e71ec017-d64e-4594-a0c2-fd60a87e9147" />

<br>
<img width="1530" height="655" alt="image" src="https://github.com/user-attachments/assets/8bf94905-9513-4361-99ae-c74497861db9" />


#1057
