### PR TITLE
Remove S3 PDF storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 
 .build
+.venv
 node_modules
 thinkhazard/static/build
 thinkhazard/static/fonts

--- a/tests/views/test_report.py
+++ b/tests/views/test_report.py
@@ -17,10 +17,9 @@
 # You should have received a copy of the GNU General Public License along with
 # ThinkHazard.  If not, see <http://www.gnu.org/licenses/>.
 import os
-import shutil
-import asyncio
 import tempfile
-from unittest.mock import patch, Mock
+from io import BytesIO
+from unittest.mock import patch
 
 from . import BaseTestCase
 
@@ -147,12 +146,10 @@ class TestReportFunction(BaseTestCase):
         resp = self.testapp.get("/en/report/12-slug/EQ")
         self.assertEqual(len(resp.pyquery(".contacts ul li")), 0)
 
-    @patch('thinkhazard.views.pdf.create_and_upload_pdf')
+    @patch('thinkhazard.views.pdf.create_pdf')
     def test_create_pdf_report(self, mock):
-        # thanks to https://stackoverflow.com/a/29905620
-        async def create(request, file_name, pages, object_name):
-            with open(file_name, "w") as file:
-                file.write("The pdf file")
+        async def create(request, pages):
+            return BytesIO("The pdf file".encode())
 
         mock.side_effect = create
         resp = self.testapp.post("/en/report/create/32", status=200)

--- a/thinkhazard/views/pdf.py
+++ b/thinkhazard/views/pdf.py
@@ -21,15 +21,13 @@ import asyncio
 import datetime
 import logging
 import re
-import tempfile
-import os
 
 from typing import List
 
 import httpx
 from pyramid.view import view_config
 from pyramid.httpexceptions import HTTPBadRequest
-from pyramid.response import FileResponse
+from pyramid.response import Response
 
 from io import BytesIO
 from pypdf import PdfReader, PdfWriter
@@ -104,7 +102,7 @@ def pdf_cover(request):
 """pdf_about: see index.py"""
 
 
-async def create_and_upload_pdf(request, file_name: str, pages: List[str], object_name: str):
+async def create_pdf(request, pages: List[str]) -> BytesIO:
     """Create a PDF file with the given pages using pyppeteer.
     """
     async def render_page(page):
@@ -143,56 +141,48 @@ async def create_and_upload_pdf(request, file_name: str, pages: List[str], objec
         for page in reader.pages:
             writer.add_page(page)
 
-    with open(file_name, "wb") as output:
-        writer.write(output)
-
-    request.s3_helper.upload_file(file_name, object_name)
+    stream = BytesIO()
+    writer.write(stream)
+    return stream
 
 
 @view_config(route_name="create_pdf_report")
 def create_pdf_report(request):
     """View to create an asynchronous print job.
     """
-    publication_date = request.publication_date
-    locale = request.locale_name
     division_code = request.matchdict.get("divisioncode")
-    force = "force" in request.params
 
-    filename = "{:s}-{:s}.pdf".format(division_code, locale)
-    s3_path = "reports/{:%Y-%m-%d}/{}".format(publication_date, filename)
-    local_path = os.path.join(tempfile.gettempdir(), filename)
-
-    if not force and request.s3_helper.object_exists(s3_path):
-        request.s3_helper.download_file(s3_path, local_path)
-
-    if force or not os.path.isfile(local_path):
-        categories = (
-            request.dbsession.query(HazardCategory)
-            .options(joinedload(HazardCategory.hazardtype))
-            .join(HazardCategoryAdministrativeDivisionAssociation)
-            .join(AdministrativeDivision)
-            .join(HazardLevel)
-            .filter(AdministrativeDivision.code == division_code)
-            .order_by(HazardLevel.order)
-        )
-        query_args = {"_query": {"_LOCALE_": request.locale_name}}
-        pages = [
-            request.route_path("pdf_cover", divisioncode=division_code, **query_args),
-            request.route_path("pdf_about", **query_args),
-        ]
-        for cat in categories:
-            pages.append(
-                request.route_path(
-                    "report_print",
-                    divisioncode=division_code,
-                    hazardtype=cat.hazardtype.mnemonic,
-                    **query_args,
-                )
+    categories = (
+        request.dbsession.query(HazardCategory)
+        .options(joinedload(HazardCategory.hazardtype))
+        .join(HazardCategoryAdministrativeDivisionAssociation)
+        .join(AdministrativeDivision)
+        .join(HazardLevel)
+        .filter(AdministrativeDivision.code == division_code)
+        .order_by(HazardLevel.order)
+    )
+    query_args = {"_query": {"_LOCALE_": request.locale_name}}
+    pages = [
+        request.route_path("pdf_cover", divisioncode=division_code, **query_args),
+        request.route_path("pdf_about", **query_args),
+    ]
+    for cat in categories:
+        pages.append(
+            request.route_path(
+                "report_print",
+                divisioncode=division_code,
+                hazardtype=cat.hazardtype.mnemonic,
+                **query_args,
             )
-        run(create_and_upload_pdf(request, local_path, pages, s3_path))
+        )
+    stream = run(create_pdf(request, pages))
+    stream.seek(0)
 
-    response = FileResponse(local_path, request=request, content_type="application/pdf")
+    response = Response(
+        content_type="application/pdf",
+    )
     response.headers["Content-Disposition"] = (
         'attachment; filename="ThinkHazard.pdf"'
     )
+    response.app_iter = stream
     return response


### PR DESCRIPTION
Remove S3 caching for PDF generation.

Previously, the PDF was generated, saved to a local temp file, uploaded to S3, and served via `FileResponse`. On subsequent requests, the cached version was downloaded from S3 if it already existed.

The PDF is now generated on every request and streamed directly in the HTTP response.